### PR TITLE
Some vkd3d-shader cleanups

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -221,7 +221,6 @@ struct vkd3d_shader_effective_uav_counter_binding_info
 enum vkd3d_shader_target
 {
     VKD3D_SHADER_TARGET_NONE,
-    VKD3D_SHADER_TARGET_SPIRV_OPENGL_4_5,
     VKD3D_SHADER_TARGET_SPIRV_VULKAN_1_0, /* default target */
 
     VKD3D_FORCE_32_BIT_ENUM(VKD3D_SHADER_TARGET),

--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -149,16 +149,6 @@ struct vkd3d_shader_resource_binding
 
 #define VKD3D_DUMMY_SAMPLER_INDEX ~0u
 
-struct vkd3d_shader_combined_resource_sampler
-{
-    unsigned int resource_index;
-    unsigned int sampler_index;
-    enum vkd3d_shader_visibility shader_visibility;
-    unsigned int flags; /* vkd3d_shader_binding_flags */
-
-    struct vkd3d_shader_descriptor_binding binding;
-};
-
 struct vkd3d_shader_uav_counter_binding
 {
     unsigned int register_space;
@@ -190,9 +180,6 @@ struct vkd3d_shader_interface_info
 
     const struct vkd3d_shader_push_constant_buffer *push_constant_buffers;
     unsigned int push_constant_buffer_count;
-
-    const struct vkd3d_shader_combined_resource_sampler *combined_samplers;
-    unsigned int combined_sampler_count;
 
     const struct vkd3d_shader_uav_counter_binding *uav_counters;
     unsigned int uav_counter_count;

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -2440,8 +2440,8 @@ static struct vkd3d_shader_descriptor_binding vkd3d_dxbc_compiler_get_descriptor
                 return current->binding;
         }
         if (shader_interface->binding_count)
-            FIXME("Could not find binding for type %#x, register %u, shader type %#x.\n",
-                    descriptor_type, reg_idx, compiler->shader_type);
+            FIXME("Could not find binding for type %#x, register %u, space %u, shader type %#x.\n",
+                    descriptor_type, reg_idx, reg_space, compiler->shader_type);
     }
 
     binding.set = 0;

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -116,7 +116,6 @@ static int vkd3d_shader_validate_compile_args(const struct vkd3d_shader_compile_
 
     switch (compile_args->target)
     {
-        case VKD3D_SHADER_TARGET_SPIRV_OPENGL_4_5:
         case VKD3D_SHADER_TARGET_SPIRV_VULKAN_1_0:
             break;
         default:

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -1541,8 +1541,6 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
     shader_interface.binding_count = root_signature->descriptor_count;
     shader_interface.push_constant_buffers = root_signature->root_constants;
     shader_interface.push_constant_buffer_count = root_signature->root_constant_count;
-    shader_interface.combined_samplers = NULL;
-    shader_interface.combined_sampler_count = 0;
     shader_interface.uav_counters = state->uav_counters;
     shader_interface.uav_counter_count = vkd3d_popcount(state->uav_counter_mask);
 
@@ -2266,8 +2264,6 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     shader_interface.binding_count = root_signature->descriptor_count;
     shader_interface.push_constant_buffers = root_signature->root_constants;
     shader_interface.push_constant_buffer_count = root_signature->root_constant_count;
-    shader_interface.combined_samplers = NULL;
-    shader_interface.combined_sampler_count = 0;
     shader_interface.uav_counters = NULL;
     shader_interface.uav_counter_count = 0;
 
@@ -2963,8 +2959,6 @@ HRESULT vkd3d_uav_clear_state_init(struct vkd3d_uav_clear_state *state, struct d
     shader_interface.binding_count = 1;
     shader_interface.push_constant_buffers = &push_constant;
     shader_interface.push_constant_buffer_count = 1;
-    shader_interface.combined_samplers = NULL;
-    shader_interface.combined_sampler_count = 0;
     shader_interface.uav_counters = NULL;
     shader_interface.uav_counter_count = 0;
 


### PR DESCRIPTION
Addresses some annoyances I encountered while working on the binding model.

Drops OpenGL-related code since that will be just dead weight and untested anyway.