### PR TITLE
Temporary UAV counter rework

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -536,15 +536,20 @@ struct vkd3d_versioned_root_signature_desc
 };
 
 /* FIXME: Add support for 64 UAV bind slots. */
-#define VKD3D_SHADER_MAX_UNORDERED_ACCESS_VIEWS 8
+#define VKD3D_SHADER_MAX_UNORDERED_ACCESS_VIEWS 64
+
+enum vkd3d_shader_uav_flag
+{
+    VKD3D_SHADER_UAV_FLAG_READ_ACCESS     = 0x00000001,
+    VKD3D_SHADER_UAV_FLAG_ATOMIC_COUNTER  = 0x00000002,
+};
 
 struct vkd3d_shader_scan_info
 {
     enum vkd3d_shader_structure_type type;
     void *next;
 
-    unsigned int uav_read_mask;    /* VKD3D_SHADER_MAX_UNORDERED_ACCESS_VIEWS */
-    unsigned int uav_counter_mask; /* VKD3D_SHADER_MAX_UNORDERED_ACCESS_VIEWS */
+    unsigned int uav_flags[VKD3D_SHADER_MAX_UNORDERED_ACCESS_VIEWS]; /* vkd3d_shader_uav_flags */
     unsigned int sampler_comparison_mode_mask; /* 16 */
     bool use_vocp;
 };

--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -35,7 +35,6 @@ enum vkd3d_shader_structure_type
     VKD3D_SHADER_STRUCTURE_TYPE_SCAN_INFO,
     VKD3D_SHADER_STRUCTURE_TYPE_TRANSFORM_FEEDBACK_INFO,
     VKD3D_SHADER_STRUCTURE_TYPE_DOMAIN_SHADER_COMPILE_ARGUMENTS,
-    VKD3D_SHADER_STRUCTURE_TYPE_EFFECTIVE_UAV_COUNTER_BINDING_INFO,
 
     VKD3D_FORCE_32_BIT_ENUM(VKD3D_SHADER_STRUCTURE_TYPE),
 };
@@ -86,8 +85,9 @@ struct vkd3d_shader_descriptor_binding
 
 enum vkd3d_shader_binding_flag
 {
-    VKD3D_SHADER_BINDING_FLAG_BUFFER = 0x00000001,
-    VKD3D_SHADER_BINDING_FLAG_IMAGE  = 0x00000002,
+    VKD3D_SHADER_BINDING_FLAG_BUFFER  = 0x00000001,
+    VKD3D_SHADER_BINDING_FLAG_IMAGE   = 0x00000002,
+    VKD3D_SHADER_BINDING_FLAG_COUNTER = 0x00000004,
 
     VKD3D_FORCE_32_BIT_ENUM(VKD3D_SHADER_BINDING_FLAG),
 };
@@ -149,17 +149,6 @@ struct vkd3d_shader_resource_binding
 
 #define VKD3D_DUMMY_SAMPLER_INDEX ~0u
 
-struct vkd3d_shader_uav_counter_binding
-{
-    unsigned int register_space;
-    unsigned int register_index; /* u# */
-    enum vkd3d_shader_visibility shader_visibility;
-    unsigned int counter_index;
-
-    struct vkd3d_shader_descriptor_binding binding;
-    unsigned int offset;
-};
-
 struct vkd3d_shader_push_constant_buffer
 {
     unsigned int register_space;
@@ -180,9 +169,6 @@ struct vkd3d_shader_interface_info
 
     const struct vkd3d_shader_push_constant_buffer *push_constant_buffers;
     unsigned int push_constant_buffer_count;
-
-    const struct vkd3d_shader_uav_counter_binding *uav_counters;
-    unsigned int uav_counter_count;
 };
 
 struct vkd3d_shader_transform_feedback_element
@@ -205,17 +191,6 @@ struct vkd3d_shader_transform_feedback_info
     unsigned int element_count;
     const unsigned int *buffer_strides;
     unsigned int buffer_stride_count;
-};
-
-/* Extends vkd3d_shader_interface_info. */
-struct vkd3d_shader_effective_uav_counter_binding_info
-{
-    enum vkd3d_shader_structure_type type;
-    const void *next;
-
-    unsigned int *uav_register_spaces;
-    unsigned int *uav_register_bindings;
-    unsigned int uav_counter_count;
 };
 
 enum vkd3d_shader_target

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -22,9 +22,6 @@
 
 VKD3D_DEBUG_ENV_NAME("VKD3D_SHADER_DEBUG");
 
-STATIC_ASSERT(MEMBER_SIZE(struct vkd3d_shader_scan_info, uav_counter_mask) * CHAR_BIT >= VKD3D_SHADER_MAX_UNORDERED_ACCESS_VIEWS);
-STATIC_ASSERT(MEMBER_SIZE(struct vkd3d_shader_scan_info, uav_read_mask) * CHAR_BIT >= VKD3D_SHADER_MAX_UNORDERED_ACCESS_VIEWS);
-
 static void vkd3d_shader_dump_blob(const char *path, const char *prefix, const void *data, size_t size,
         unsigned int id, const char *ext)
 {
@@ -229,7 +226,7 @@ static void vkd3d_shader_scan_record_uav_read(struct vkd3d_shader_scan_info *sca
         const struct vkd3d_shader_register *reg)
 {
     assert(reg->idx[0].offset < VKD3D_SHADER_MAX_UNORDERED_ACCESS_VIEWS);
-    scan_info->uav_read_mask |= 1u << reg->idx[0].offset;
+    scan_info->uav_flags[reg->idx[0].offset] |= VKD3D_SHADER_UAV_FLAG_READ_ACCESS;
 }
 
 static bool vkd3d_shader_instruction_is_uav_counter(const struct vkd3d_shader_instruction *instruction)
@@ -243,7 +240,7 @@ static void vkd3d_shader_scan_record_uav_counter(struct vkd3d_shader_scan_info *
         const struct vkd3d_shader_register *reg)
 {
     assert(reg->idx[0].offset < VKD3D_SHADER_MAX_UNORDERED_ACCESS_VIEWS);
-    scan_info->uav_counter_mask |= 1u << reg->idx[0].offset;
+    scan_info->uav_flags[reg->idx[0].offset] |= VKD3D_SHADER_UAV_FLAG_ATOMIC_COUNTER;
 }
 
 static void vkd3d_shader_scan_input_declaration(struct vkd3d_shader_scan_info *scan_info,

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2573,11 +2573,12 @@ static void d3d12_command_list_prepare_descriptors(struct d3d12_command_list *li
 static bool vk_write_descriptor_set_from_d3d12_desc(VkWriteDescriptorSet *vk_descriptor_write,
         VkDescriptorImageInfo *vk_image_info, const struct d3d12_desc *descriptor,
         uint32_t descriptor_range_magic, VkDescriptorSet vk_descriptor_set,
-        uint32_t vk_binding, unsigned int index)
+        uint32_t vk_binding, unsigned int index, bool uav_counter)
 {
     const struct vkd3d_view *view = descriptor->u.view;
+    bool is_uav = descriptor->magic == VKD3D_DESCRIPTOR_MAGIC_UAV;
 
-    if (descriptor->magic != descriptor_range_magic)
+    if (descriptor->magic != descriptor_range_magic || (uav_counter && !is_uav))
         return false;
 
     vk_descriptor_write->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -2601,7 +2602,7 @@ static bool vk_write_descriptor_set_from_d3d12_desc(VkWriteDescriptorSet *vk_des
         case VKD3D_DESCRIPTOR_MAGIC_UAV:
             /* We use separate bindings for buffer and texture SRVs/UAVs.
              * See d3d12_root_signature_init(). */
-            vk_descriptor_write->dstBinding = vk_binding + 2 * index;
+            vk_descriptor_write->dstBinding = vk_binding + (is_uav ? 3 : 2) * index;
             if (descriptor->vk_descriptor_type != VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER
                     && descriptor->vk_descriptor_type != VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)
                 ++vk_descriptor_write->dstBinding;
@@ -2609,7 +2610,18 @@ static bool vk_write_descriptor_set_from_d3d12_desc(VkWriteDescriptorSet *vk_des
             if (descriptor->vk_descriptor_type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER
                     || descriptor->vk_descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)
             {
-                vk_descriptor_write->pTexelBufferView = &view->u.vk_buffer_view;
+                if (uav_counter)
+                {
+                    vk_descriptor_write->dstBinding += 2;
+                    vk_descriptor_write->pTexelBufferView = &view->vk_counter_view;
+
+                    if (!view->vk_counter_view)
+                        return false;
+                }
+                else
+                {
+                    vk_descriptor_write->pTexelBufferView = &view->u.vk_buffer_view;
+                }
             }
             else
             {
@@ -2671,14 +2683,25 @@ static void d3d12_command_list_update_descriptor_table(struct d3d12_command_list
         {
             if (!vk_write_descriptor_set_from_d3d12_desc(current_descriptor_write,
                     current_image_info, descriptor, range->descriptor_magic,
-                    bindings->descriptor_set, range->binding, j))
+                    bindings->descriptor_set, range->binding, j, false))
                 continue;
 
             ++descriptor_count;
             ++current_descriptor_write;
             ++current_image_info;
 
-            if (descriptor_count == ARRAY_SIZE(descriptor_writes))
+            if (vk_write_descriptor_set_from_d3d12_desc(current_descriptor_write,
+                    current_image_info, descriptor, range->descriptor_magic,
+                    bindings->descriptor_set, range->binding, j, true))
+            {
+                ++descriptor_count;
+                ++current_descriptor_write;
+                ++current_image_info;
+            }
+
+            /* We may write up to two descriptors per iteration, so
+             * make sure there's enough space left in the array. */
+            if (descriptor_count >= ARRAY_SIZE(descriptor_writes) - 1)
             {
                 VK_CALL(vkUpdateDescriptorSets(vk_device, descriptor_count, descriptor_writes, 0, NULL));
                 descriptor_count = 0;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -1414,8 +1414,6 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
     shader_interface.binding_count = root_signature->descriptor_count;
     shader_interface.push_constant_buffers = root_signature->root_constants;
     shader_interface.push_constant_buffer_count = root_signature->root_constant_count;
-    shader_interface.uav_counters = NULL;
-    shader_interface.uav_counter_count = 0;
 
     if (FAILED(hr = vkd3d_create_compute_pipeline(device, &desc->CS, &shader_interface,
             root_signature->vk_pipeline_layout, &state->u.compute.vk_pipeline)))
@@ -2104,8 +2102,6 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     shader_interface.binding_count = root_signature->descriptor_count;
     shader_interface.push_constant_buffers = root_signature->root_constants;
     shader_interface.push_constant_buffer_count = root_signature->root_constant_count;
-    shader_interface.uav_counters = NULL;
-    shader_interface.uav_counter_count = 0;
 
     for (i = 0; i < ARRAY_SIZE(shader_stages); ++i)
     {
@@ -2788,8 +2784,6 @@ HRESULT vkd3d_uav_clear_state_init(struct vkd3d_uav_clear_state *state, struct d
     shader_interface.binding_count = 1;
     shader_interface.push_constant_buffers = &push_constant;
     shader_interface.push_constant_buffer_count = 1;
-    shader_interface.uav_counters = NULL;
-    shader_interface.uav_counter_count = 0;
 
     for (i = 0; i < ARRAY_SIZE(pipelines); ++i)
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -795,13 +795,6 @@ struct d3d12_pipeline_state
     } u;
     VkPipelineBindPoint vk_bind_point;
 
-    VkPipelineLayout vk_pipeline_layout;
-    VkDescriptorSetLayout vk_set_layout;
-    uint32_t set_index;
-
-    struct vkd3d_shader_uav_counter_binding *uav_counters;
-    uint8_t uav_counter_mask;
-
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;
@@ -921,9 +914,6 @@ struct vkd3d_pipeline_bindings
     D3D12_GPU_DESCRIPTOR_HANDLE descriptor_tables[D3D12_MAX_ROOT_COST];
     uint64_t descriptor_table_dirty_mask;
     uint64_t descriptor_table_active_mask;
-
-    VkBufferView vk_uav_counter_views[VKD3D_SHADER_MAX_UNORDERED_ACCESS_VIEWS];
-    uint8_t uav_counter_dirty_mask;
 
     /* Needed when VK_KHR_push_descriptor is not available. */
     struct vkd3d_push_descriptor push_descriptors[D3D12_MAX_ROOT_COST / 2];


### PR DESCRIPTION
In preparation for the bindless implementation, this makes the following changes to UAV counter handling:
- UAV counters are packed into the root signature's descriptor set layout for now. This allows us to get rid of per-pipeline descriptor set layouts and pipeline layouts, and gretaly simplifies descriptor updates involving UAV counters.
- UAV counter bindings are passed to vkd3d-shader as regular resource bindings in order to avoid some duplication.

As part of the bindless implementation, I plan to rewrite `d3d12_command_list_update_descriptors` as well as `d3d12_root_signature_init` completely from scratch. While those parts are currently messy, they hopefully won't stay that way for long.

It's probably worth testing WoW with thsese patches, which I haven't done yet. SotTR and Metro still work as expected and they don't introduce new test failures.