### PR TITLE
vkd3d: Attempt to create a Vulkan 1.1 instance and device.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -481,6 +481,7 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
     VkInstance vk_instance;
     VkResult vr;
     HRESULT hr;
+    uint32_t loader_version = VK_API_VERSION_1_0;
 
     TRACE("Build: %s.\n", vkd3d_build);
 
@@ -521,13 +522,20 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
         return hr;
     }
 
+    if (vk_global_procs->vkEnumerateInstanceVersion)
+        vk_global_procs->vkEnumerateInstanceVersion(&loader_version);
+
+    /* Do not opt-in to versions we don't need yet. */
+    if (loader_version > VK_API_VERSION_1_1)
+        loader_version = VK_API_VERSION_1_1;
+
     application_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
     application_info.pNext = NULL;
     application_info.pApplicationName = NULL;
     application_info.applicationVersion = 0;
     application_info.pEngineName = PACKAGE_NAME;
     application_info.engineVersion = vkd3d_get_vk_version();
-    application_info.apiVersion = VK_API_VERSION_1_0;
+    application_info.apiVersion = loader_version;
 
     if ((vkd3d_application_info = vkd3d_find_struct(create_info->next, APPLICATION_INFO)))
     {
@@ -592,8 +600,13 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
     }
 
     instance->vk_instance = vk_instance;
+    instance->instance_version = loader_version;
 
     TRACE("Created Vulkan instance %p.\n", vk_instance);
+    if (loader_version == VK_API_VERSION_1_1)
+        TRACE("Created Vulkan 1.1 instance.\n");
+    else
+        TRACE("Created Vulkan 1.0 instance.\n");
 
     instance->refcount = 1;
 
@@ -1731,6 +1744,8 @@ static HRESULT vkd3d_create_vk_device(struct d3d12_device *device,
     VkDevice vk_device;
     VkResult vr;
     HRESULT hr;
+    VkPhysicalDeviceProperties device_properties;
+    bool use_vulkan_11;
 
     TRACE("device %p, create_info %p.\n", device, create_info);
 
@@ -1741,6 +1756,11 @@ static HRESULT vkd3d_create_vk_device(struct d3d12_device *device,
         return hr;
 
     device->vk_physical_device = physical_device;
+
+    VK_CALL(vkGetPhysicalDeviceProperties(device->vk_physical_device, &device_properties));
+    use_vulkan_11 = device_properties.apiVersion >= VK_API_VERSION_1_1 &&
+                    device->vkd3d_instance->instance_version >= VK_API_VERSION_1_1;
+    device->api_version = use_vulkan_11 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0;
 
     if (FAILED(hr = vkd3d_select_queues(device->vkd3d_instance, physical_device, &device_queue_info)))
         return hr;

--- a/libs/vkd3d/utils.c
+++ b/libs/vkd3d/utils.c
@@ -798,6 +798,8 @@ HRESULT hresult_from_vkd3d_result(int vkd3d_result)
         ERR("Could not get global proc addr for '" #name "'.\n"); \
         return E_FAIL; \
     }
+#define MAYBE_LOAD_GLOBAL_PFN(name) \
+    procs->name = (void *)vkGetInstanceProcAddr(NULL, #name);
 
 HRESULT vkd3d_load_vk_global_procs(struct vkd3d_vk_global_procs *procs,
         PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr)
@@ -808,6 +810,7 @@ HRESULT vkd3d_load_vk_global_procs(struct vkd3d_vk_global_procs *procs,
 
     LOAD_GLOBAL_PFN(vkCreateInstance)
     LOAD_GLOBAL_PFN(vkEnumerateInstanceExtensionProperties)
+    MAYBE_LOAD_GLOBAL_PFN(vkEnumerateInstanceVersion)
 
     TRACE("Loaded global Vulkan procs.\n");
     return S_OK;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -61,6 +61,7 @@ struct d3d12_resource;
 struct vkd3d_vk_global_procs
 {
     PFN_vkCreateInstance vkCreateInstance;
+    PFN_vkEnumerateInstanceVersion vkEnumerateInstanceVersion;
     PFN_vkEnumerateInstanceExtensionProperties vkEnumerateInstanceExtensionProperties;
     PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr;
 };
@@ -135,6 +136,7 @@ enum vkd3d_config_flags
 struct vkd3d_instance
 {
     VkInstance vk_instance;
+    uint32_t instance_version;
     struct vkd3d_vk_instance_procs vk_procs;
 
     PFN_vkd3d_signal_event signal_event;
@@ -1108,6 +1110,7 @@ struct d3d12_device
     LONG refcount;
 
     VkDevice vk_device;
+    uint32_t api_version;
     VkPhysicalDevice vk_physical_device;
     struct vkd3d_vk_device_procs vk_procs;
     PFN_vkd3d_signal_event signal_event;


### PR DESCRIPTION
Need this to support subgroup operations for SM 6.0.