### PR TITLE
vkd3d: Create NULL buffer and image views.

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -20,7 +20,8 @@
 #include "vkd3d_private.h"
 
 #define VKD3D_NULL_BUFFER_SIZE 16
-#define VKD3D_NULL_VIEW_FORMAT DXGI_FORMAT_R8G8B8A8_UNORM
+#define VKD3D_NULL_SRV_FORMAT DXGI_FORMAT_R8G8B8A8_UNORM
+#define VKD3D_NULL_UAV_FORMAT DXGI_FORMAT_R32_UINT
 
 static inline bool is_cpu_accessible_heap(const D3D12_HEAP_PROPERTIES *properties)
 {
@@ -2699,7 +2700,7 @@ static void vkd3d_create_null_srv(struct d3d12_desc *descriptor,
 
     WARN("Creating NULL SRV %#x.\n", desc->ViewDimension);
 
-    vkd3d_desc.format = vkd3d_get_format(device, VKD3D_NULL_VIEW_FORMAT, false);
+    vkd3d_desc.format = vkd3d_get_format(device, VKD3D_NULL_SRV_FORMAT, false);
     vkd3d_desc.miplevel_idx = 0;
     vkd3d_desc.miplevel_count = 1;
     vkd3d_desc.layer_idx = 0;
@@ -2906,7 +2907,7 @@ static void vkd3d_create_null_uav(struct d3d12_desc *descriptor,
 
     WARN("Creating NULL UAV %#x.\n", desc->ViewDimension);
 
-    vkd3d_desc.format = vkd3d_get_format(device, VKD3D_NULL_VIEW_FORMAT, false);
+    vkd3d_desc.format = vkd3d_get_format(device, VKD3D_NULL_UAV_FORMAT, false);
     vkd3d_desc.miplevel_idx = 0;
     vkd3d_desc.miplevel_count = 1;
     vkd3d_desc.layer_idx = 0;
@@ -4111,7 +4112,7 @@ HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
     resource_desc.Height = 1;
     resource_desc.DepthOrArraySize = 1;
     resource_desc.MipLevels = 1;
-    resource_desc.Format = VKD3D_NULL_VIEW_FORMAT;
+    resource_desc.Format = VKD3D_NULL_SRV_FORMAT;
     resource_desc.SampleDesc.Count = 1;
     resource_desc.SampleDesc.Quality = 0;
     resource_desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
@@ -4131,7 +4132,7 @@ HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
     resource_desc.Height = 1;
     resource_desc.DepthOrArraySize = 1;
     resource_desc.MipLevels = 1;
-    resource_desc.Format = VKD3D_NULL_VIEW_FORMAT;
+    resource_desc.Format = VKD3D_NULL_UAV_FORMAT;
     resource_desc.SampleDesc.Count = 1;
     resource_desc.SampleDesc.Quality = 0;
     resource_desc.Layout = use_sparse_resources

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1061,6 +1061,8 @@ struct vkd3d_null_resources
     VkImage vk_2d_storage_image;
     VkImageView vk_2d_storage_image_view;
     VkDeviceMemory vk_2d_storage_image_memory;
+
+    VkSampler vk_sampler;
 };
 
 HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1047,15 +1047,19 @@ struct d3d12_command_signature *unsafe_impl_from_ID3D12CommandSignature(ID3D12Co
 struct vkd3d_null_resources
 {
     VkBuffer vk_buffer;
+    VkBufferView vk_buffer_view;
     VkDeviceMemory vk_buffer_memory;
 
     VkBuffer vk_storage_buffer;
+    VkBufferView vk_storage_buffer_view;
     VkDeviceMemory vk_storage_buffer_memory;
 
     VkImage vk_2d_image;
+    VkImageView vk_2d_image_view;
     VkDeviceMemory vk_2d_image_memory;
 
     VkImage vk_2d_storage_image;
+    VkImageView vk_2d_storage_image_view;
     VkDeviceMemory vk_2d_storage_image_memory;
 };
 


### PR DESCRIPTION
Currently, we leave descriptors undefined that are either left uninitialized by the application or have the wrong resource type bound. However, this causes issues when using descriptor update templates since we need to provide a valid view handle for all descriptors that are to be updated.

Providing these may then also improve stability with misbehaving applications that access an undefined descriptor in a shader.

Note that this is different from the explicit NULL descriptors that the application can create using `CreateShaderResourceView` and friends.