### PR TITLE
Binding model: Bindless part 2

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1327,6 +1327,8 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
         device->feature_options.TiledResourcesTier = D3D12_TILED_RESOURCES_TIER_NOT_SUPPORTED;
     }
 
+    /* FIXME We only support bindless for TIER_2 at the moment, but WoW
+     * requires TIER_3 support to offer D3D12 as an option at all */
     if (device->vk_info.device_limits.maxPerStageDescriptorSamplers <= 16)
         device->feature_options.ResourceBindingTier = D3D12_RESOURCE_BINDING_TIER_1;
     else if (device->vk_info.device_limits.maxPerStageDescriptorUniformBuffers <= 14)

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -807,9 +807,11 @@ cleanup:
 static HRESULT d3d12_root_signature_init(struct d3d12_root_signature *root_signature,
         struct d3d12_device *device, const D3D12_ROOT_SIGNATURE_DESC *desc)
 {
+    const struct vkd3d_bindless_state *bindless_state = &device->bindless_state;
+    VkDescriptorSetLayout set_layouts[VKD3D_MAX_DESCRIPTOR_SETS];
     struct vkd3d_descriptor_set_context context;
     struct d3d12_root_signature_info info;
-    VkDescriptorSetLayout set_layouts[3];
+    unsigned int i;
     HRESULT hr;
 
     memset(&context, 0, sizeof(context));
@@ -854,6 +856,9 @@ static HRESULT d3d12_root_signature_init(struct d3d12_root_signature *root_signa
     if (!(root_signature->static_samplers = vkd3d_calloc(root_signature->static_sampler_count,
             sizeof(*root_signature->static_samplers))))
         goto fail;
+
+    for (i = 0; i < bindless_state->set_count; i++)
+        set_layouts[context.vk_set++] = bindless_state->set_info[i].vk_set_layout;
 
     if (FAILED(hr = d3d12_root_signature_init_static_samplers(root_signature, desc,
                 &context, &root_signature->vk_sampler_descriptor_layout)))

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2764,8 +2764,22 @@ static HRESULT vkd3d_bindless_state_add_binding(struct vkd3d_bindless_state *bin
 
 static uint32_t vkd3d_bindless_state_get_bindless_flags(struct d3d12_device *device)
 {
-    /* FIXME implement proper feature check */
-    return 0;
+    const struct vkd3d_physical_device_info *device_info = &device->device_info;
+    const struct vkd3d_vulkan_info *vk_info = &device->vk_info;
+    uint32_t flags = 0;
+
+    if (!vk_info->EXT_descriptor_indexing ||
+            !device_info->descriptor_indexing_features.runtimeDescriptorArray ||
+            !device_info->descriptor_indexing_features.descriptorBindingPartiallyBound ||
+            !device_info->descriptor_indexing_features.descriptorBindingVariableDescriptorCount)
+        return 0;
+
+    if (device_info->descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindSampledImages >= 1000000 &&
+            device_info->descriptor_indexing_features.shaderSampledImageArrayNonUniformIndexing &&
+            device_info->descriptor_indexing_features.shaderUniformTexelBufferArrayNonUniformIndexing)
+        flags |= VKD3D_BINDLESS_SAMPLER | VKD3D_BINDLESS_SRV;
+
+    return flags;
 }
 
 HRESULT vkd3d_bindless_state_init(struct vkd3d_bindless_state *bindless_state,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -959,6 +959,7 @@ struct vkd3d_pipeline_bindings
     D3D12_GPU_DESCRIPTOR_HANDLE descriptor_tables[D3D12_MAX_ROOT_COST];
     uint64_t descriptor_table_dirty_mask;
     uint64_t descriptor_table_active_mask;
+    uint64_t descriptor_heap_dirty_mask;
 
     /* Needed when VK_KHR_push_descriptor is not available. */
     union vkd3d_descriptor_info root_descriptors[D3D12_MAX_ROOT_COST / 2];
@@ -1004,6 +1005,8 @@ struct d3d12_command_list
     VkRenderPass current_render_pass;
     struct vkd3d_pipeline_bindings pipeline_bindings[VK_PIPELINE_BIND_POINT_RANGE_SIZE];
     struct vkd3d_descriptor_updates packed_descriptors[VK_PIPELINE_BIND_POINT_RANGE_SIZE];
+
+    VkDescriptorSet descriptor_heaps[VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS];
 
     struct d3d12_pipeline_state *state;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -54,6 +54,7 @@
 #define VKD3D_MAX_SHADER_STAGES           5u
 #define VKD3D_MAX_VK_SYNC_OBJECTS         4u
 
+#define VKD3D_MAX_DESCRIPTOR_SETS 8u
 #define VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS 6u
 
 struct d3d12_command_list;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1146,6 +1146,9 @@ HRESULT vkd3d_bindless_state_init(struct vkd3d_bindless_state *bindless_state,
         struct d3d12_device *device) DECLSPEC_HIDDEN;
 void vkd3d_bindless_state_cleanup(struct vkd3d_bindless_state *bindless_state,
         struct d3d12_device *device) DECLSPEC_HIDDEN;
+bool vkd3d_bindless_state_find_binding(const struct vkd3d_bindless_state *bindless_state,
+        D3D12_DESCRIPTOR_RANGE_TYPE range_type, enum vkd3d_shader_binding_flag binding_flag,
+        struct vkd3d_shader_descriptor_binding *binding) DECLSPEC_HIDDEN;
 
 VkDescriptorType vk_descriptor_type_from_bindless_set_info(const struct vkd3d_bindless_set_info *set_info) DECLSPEC_HIDDEN;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1195,6 +1195,29 @@ struct vkd3d_uav_clear_state
 HRESULT vkd3d_uav_clear_state_init(struct vkd3d_uav_clear_state *state, struct d3d12_device *device) DECLSPEC_HIDDEN;
 void vkd3d_uav_clear_state_cleanup(struct vkd3d_uav_clear_state *state, struct d3d12_device *device) DECLSPEC_HIDDEN;
 
+struct vkd3d_physical_device_info
+{
+    /* properties */
+    VkPhysicalDeviceDescriptorIndexingPropertiesEXT descriptor_indexing_properties;
+    VkPhysicalDeviceMaintenance3Properties maintenance3_properties;
+    VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT texel_buffer_alignment_properties;
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT xfb_properties;
+    VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT vertex_divisor_properties;
+
+    VkPhysicalDeviceProperties2KHR properties2;
+
+    /* features */
+    VkPhysicalDeviceConditionalRenderingFeaturesEXT conditional_rendering_features;
+    VkPhysicalDeviceDepthClipEnableFeaturesEXT depth_clip_features;
+    VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptor_indexing_features;
+    VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT demote_features;
+    VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT texel_buffer_alignment_features;
+    VkPhysicalDeviceTransformFeedbackFeaturesEXT xfb_features;
+    VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT vertex_divisor_features;
+
+    VkPhysicalDeviceFeatures2 features2;
+};
+
 /* ID3D12Device */
 struct d3d12_device
 {
@@ -1221,6 +1244,7 @@ struct d3d12_device
     D3D12_FEATURE_DATA_D3D12_OPTIONS feature_options;
 
     struct vkd3d_vulkan_info vk_info;
+    struct vkd3d_physical_device_info device_info;
 
     struct vkd3d_queue *direct_queue;
     struct vkd3d_queue *compute_queue;


### PR DESCRIPTION
Implements initial support for bindless SRVs and Samplers, as well as dynamic and non-uniform descriptor indexing for Shader Model 5.1/6.0.

This consists of several parts, all of which depend on each other:
1. Shader compiler work to support these features, including some required additions to the interface between vkd3d and the shader compiler.
2. A complete rewrite of the root signature and resource binding code, which was needed since assumptions about the exact descriptor set layouts were duplicated in various places and the whole thing was barely maintainable, let alone extensible.
3. API-side additions to support bindless SRVs/Samplers.

The implementation passes both `test_bindless_srv_sm51` and `test_bindless_samplers_sm51` on AMDVLK as well as RADV with ACO (non-uniform indexing is broken on LLVM), and was further tested in Shadow of the Tomb Raider, Metro Exodus, and Resident Evil 2.

## Overview
Each descriptor heap holds one or more descriptor sets, one for each supported descriptor type. These sets are updated by functions such as `CreateShaderResourceView` and `CopyDescriptors`, and are bound to a command list via `SetDescriptorHeaps`.

The set and binding numbers for these sets are be the same for all pipeline layouts, so there is no need to rebind the sets when the root signature changes.

Descriptor table offsets are passed to the pipeline via push constants, one 32-bit integer per table, and are updated after each call to `Set*RootDescriptorTable`.

```glsl
/* Declarations */
layout(push_constant, std430) uniform push_cb {
    uint descriptor_tables[2];
} pc;
/* Descriptor heaps */
layout(set = 0, binding = 0) uniform sampler samplers[];
layout(set = 1, binding = 0) uniform usamplerBuffer srvBuf[];
layout(set = 2, binding = 0) uniform utexture2D srv2D[];
/* Root descriptor */
layout(set = 3, binding = 0, r32ui) uniform writeonly uimageBuffer u0;
/* Sample lookup */
texelFetch(srv2D[nonuniformEXT(pc.descriptor_tables[0u] + uint(floatBitsToInt(r0.x)))], ivec2(0), 0)
```

Root descriptors were also reworked to always use a separate set, even if `VK_KHR_push_descriptor` is not supported. This simplifies the design and may improve performance, since root descriptors likely change more frequently than descriptor tables. Static samplers also use a separate set now.

The packed descriptor set, root descriptor set and static sampler set are optional and will not be created if not needed by the root signature.

## Current issues
- It is not entirely clear which IDs we need to decorate with `NonUniformEXT` (is there any documentation for this?). RADV seems to be happy with pretty much anything, whereas AMDVLK requires it on both the index and the resource ID (of `OpTypeImage`/`OpTypeSampler`).
Decorating the pointer returned by `OpAccessChain` does *not* work, which complicates the design and causes some inevitable code duplication.
- We currently only enable bindless if the device reports `RESOURCE_BINDING_TIER_2` since we have no easy access to the device features and properties. A possible solution is to store a `vkd3d_physical_device_info` struct in `d3d12_device`.
- There is currently no clear path towards supporting bindless UAV counters. The original idea was to add a single SSBO descriptor to one of the bindless set layouts which would then contain the raw VAs, however this complicates the design significantly since we need to keep track of which binding to update etc. Another option which does not increase the overall set count would be to add it to the root descriptor set if necessary.
- We need a way to find the descriptor heap from a `D3D12_CPU_DESCRIPTOR_HANDLE`. The current (and somewhat ugly) solution is to initialize each descriptor with a pointer to the heap.
- There are still a few things I'd like to clean up, e.g. the way the descriptor table offset is calculated.

## Future work
- Inline uniform blocks should be used on implementations that only support 128 bytes of push constant space.
- Static samplers should be cached so that we don't exceed the limit on the number of samplers that may exist at a time. D3D12 allows up to [2032](https://docs.microsoft.com/en-us/windows/win32/direct3d12/hardware-support) unique static samplers.
- We may want to allocate static sampler descriptor sets from a global pool using `VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT`. Currently we allocate a new set each time the root signature changes.
- Support volatile descriptor ranges properly for the packed descriptor set.
- Support dynamic descriptor indexing within the packed descriptor set.
- Use `VK_EXT_buffer_address` for root descriptors to replace the root descriptor set.
- Support bindless UAVs and UAV counters.
- Support bindless CBVs on hardware that can support it.