### PR TITLE
vkd3d: Bindless CBV

### DIFF
--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2811,6 +2811,10 @@ static uint32_t vkd3d_bindless_state_get_bindless_flags(struct d3d12_device *dev
             device_info->descriptor_indexing_features.shaderUniformTexelBufferArrayNonUniformIndexing)
         flags |= VKD3D_BINDLESS_SAMPLER | VKD3D_BINDLESS_SRV;
 
+    if (device_info->descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindUniformBuffers >= 1000000 &&
+            device_info->descriptor_indexing_features.shaderUniformBufferArrayNonUniformIndexing)
+        flags |= VKD3D_BINDLESS_CBV;
+
     return flags;
 }
 


### PR DESCRIPTION
Title.

Haven't managed to write a test for non-uniform/dynamic CBV indexing so far since that seems to crash the AMD driver, but it doesn't cause any test regression (`test_constant_buffer_sm51` uses CBVs in descriptor tables and still passes) and works in Resident Evil 2, which makes use of CBV descriptor ranges.