### PR TITLE
vkd3d: Use VK_EXT_inline_uniform_block for root constants etc. if necessary

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -171,10 +171,16 @@ struct vkd3d_shader_descriptor_table_buffer
     unsigned int count;  /* number of tables */
 };
 
+enum vkd3d_shader_interface_flag
+{
+    VKD3D_SHADER_INTERFACE_PUSH_CONSTANTS_AS_UNIFORM_BUFFER = 0x00000001u,
+};
+
 struct vkd3d_shader_interface_info
 {
     enum vkd3d_shader_structure_type type;
     const void *next;
+    unsigned int flags; /* vkd3d_shader_interface_flags */
 
     struct vkd3d_shader_descriptor_table_buffer descriptor_tables;
     const struct vkd3d_shader_resource_binding *bindings;
@@ -182,6 +188,9 @@ struct vkd3d_shader_interface_info
 
     const struct vkd3d_shader_push_constant_buffer *push_constant_buffers;
     unsigned int push_constant_buffer_count;
+
+    /* Ignored unless VKD3D_SHADER_INTERFACE_PUSH_CONSTANTS_AS_UNIFORM_BUFFER is set */
+    const struct vkd3d_shader_descriptor_binding *push_constant_ubo_binding;
 };
 
 struct vkd3d_shader_transform_feedback_element

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -154,6 +154,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(EXT_DEBUG_MARKER, EXT_debug_marker),
     VK_EXTENSION(EXT_DEPTH_CLIP_ENABLE, EXT_depth_clip_enable),
     VK_EXTENSION(EXT_DESCRIPTOR_INDEXING, EXT_descriptor_indexing),
+    VK_EXTENSION(EXT_INLINE_UNIFORM_BLOCK, EXT_inline_uniform_block),
     VK_EXTENSION(EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION, EXT_shader_demote_to_helper_invocation),
     VK_EXTENSION(EXT_TEXEL_BUFFER_ALIGNMENT, EXT_texel_buffer_alignment),
     VK_EXTENSION(EXT_TRANSFORM_FEEDBACK, EXT_transform_feedback),
@@ -694,10 +695,12 @@ VkInstance vkd3d_instance_get_vk_instance(struct vkd3d_instance *instance)
 static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *info, struct d3d12_device *device)
 {
     const struct vkd3d_vk_instance_procs *vk_procs = &device->vkd3d_instance->vk_procs;
+    VkPhysicalDeviceInlineUniformBlockPropertiesEXT *inline_uniform_block_properties;
     VkPhysicalDeviceConditionalRenderingFeaturesEXT *conditional_rendering_features;
     VkPhysicalDeviceDescriptorIndexingPropertiesEXT *descriptor_indexing_properties;
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT *vertex_divisor_properties;
     VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT *buffer_alignment_properties;
+    VkPhysicalDeviceInlineUniformBlockFeaturesEXT *inline_uniform_block_features;
     VkPhysicalDeviceDescriptorIndexingFeaturesEXT *descriptor_indexing_features;
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT *vertex_divisor_features;
     VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *buffer_alignment_features;
@@ -714,6 +717,8 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     depth_clip_features = &info->depth_clip_features;
     descriptor_indexing_features = &info->descriptor_indexing_features;
     descriptor_indexing_properties = &info->descriptor_indexing_properties;
+    inline_uniform_block_features = &info->inline_uniform_block_features;
+    inline_uniform_block_properties = &info->inline_uniform_block_properties;
     maintenance3_properties = &info->maintenance3_properties;
     demote_features = &info->demote_features;
     buffer_alignment_features = &info->texel_buffer_alignment_features;
@@ -739,6 +744,8 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     vk_prepend_struct(&info->features2, xfb_features);
     vertex_divisor_features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT;
     vk_prepend_struct(&info->features2, vertex_divisor_features);
+    inline_uniform_block_features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT;
+    vk_prepend_struct(&info->features2, inline_uniform_block_features);
 
     if (vulkan_info->KHR_get_physical_device_properties2)
         VK_CALL(vkGetPhysicalDeviceFeatures2KHR(physical_device, &info->features2));
@@ -757,6 +764,8 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     vk_prepend_struct(&info->properties2, xfb_properties);
     vertex_divisor_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT;
     vk_prepend_struct(&info->properties2, vertex_divisor_properties);
+    inline_uniform_block_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT;
+    vk_prepend_struct(&info->properties2, inline_uniform_block_properties);
 
     if (vulkan_info->KHR_get_physical_device_properties2)
         VK_CALL(vkGetPhysicalDeviceProperties2KHR(physical_device, &info->properties2));

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -1468,12 +1468,14 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
 
     shader_interface.type = VKD3D_SHADER_STRUCTURE_TYPE_SHADER_INTERFACE_INFO;
     shader_interface.next = NULL;
+    shader_interface.flags = 0;
     shader_interface.descriptor_tables.offset = root_signature->descriptor_table_offset;
     shader_interface.descriptor_tables.count = root_signature->descriptor_table_count;
     shader_interface.bindings = root_signature->bindings;
     shader_interface.binding_count = root_signature->binding_count;
     shader_interface.push_constant_buffers = root_signature->root_constants;
     shader_interface.push_constant_buffer_count = root_signature->root_constant_count;
+    shader_interface.push_constant_ubo_binding = NULL;
 
     if (FAILED(hr = vkd3d_create_compute_pipeline(device, &desc->CS, &shader_interface,
             root_signature->vk_pipeline_layout, &state->u.compute.vk_pipeline)))
@@ -2158,12 +2160,14 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
 
     shader_interface.type = VKD3D_SHADER_STRUCTURE_TYPE_SHADER_INTERFACE_INFO;
     shader_interface.next = NULL;
+    shader_interface.flags = 0;
     shader_interface.descriptor_tables.offset = root_signature->descriptor_table_offset;
     shader_interface.descriptor_tables.count = root_signature->descriptor_table_count;
     shader_interface.bindings = root_signature->bindings;
     shader_interface.binding_count = root_signature->binding_count;
     shader_interface.push_constant_buffers = root_signature->root_constants;
     shader_interface.push_constant_buffer_count = root_signature->root_constant_count;
+    shader_interface.push_constant_ubo_binding = NULL;
 
     for (i = 0; i < ARRAY_SIZE(shader_stages); ++i)
     {
@@ -3038,12 +3042,14 @@ HRESULT vkd3d_uav_clear_state_init(struct vkd3d_uav_clear_state *state, struct d
 
     shader_interface.type = VKD3D_SHADER_STRUCTURE_TYPE_SHADER_INTERFACE_INFO;
     shader_interface.next = NULL;
+    shader_interface.flags = 0;
     shader_interface.descriptor_tables.offset = 0;
     shader_interface.descriptor_tables.count = 0;
     shader_interface.bindings = &binding;
     shader_interface.binding_count = 1;
     shader_interface.push_constant_buffers = &push_constant;
     shader_interface.push_constant_buffer_count = 1;
+    shader_interface.push_constant_ubo_binding = NULL;
 
     for (i = 0; i < ARRAY_SIZE(pipelines); ++i)
     {

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -851,7 +851,7 @@ static HRESULT d3d12_root_signature_init(struct d3d12_root_signature *root_signa
     root_signature->ID3D12RootSignature_iface.lpVtbl = &d3d12_root_signature_vtbl;
     root_signature->refcount = 1;
 
-    root_signature->flags = desc->Flags;
+    root_signature->d3d12_flags = desc->Flags;
 
     if (desc->Flags & ~(D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT
             | D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT))
@@ -2126,7 +2126,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     graphics->xfb_enabled = false;
     if (so_desc->NumEntries)
     {
-        if (!(root_signature->flags & D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT))
+        if (!(root_signature->d3d12_flags & D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT))
         {
             WARN("Stream output is used without D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT.\n");
             hr = E_INVALIDARG;
@@ -2228,7 +2228,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     }
 
     if (graphics->attribute_count
-            && !(root_signature->flags & D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT))
+            && !(root_signature->d3d12_flags & D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT))
     {
         WARN("Input layout is used without D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT.\n");
         hr = E_INVALIDARG;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -702,6 +702,11 @@ enum vkd3d_root_descriptor_table_flag
     VKD3D_ROOT_DESCRIPTOR_TABLE_HAS_PACKED_DESCRIPTORS = 0x00000001u,
 };
 
+enum vkd3d_root_signature_flag
+{
+    VKD3D_ROOT_SIGNATURE_USE_PUSH_DESCRIPTORS     = 0x00000001u,
+};
+
 struct d3d12_root_descriptor_table
 {
     uint32_t table_index;
@@ -757,6 +762,7 @@ struct d3d12_root_signature
     uint64_t root_descriptor_mask;
 
     D3D12_ROOT_SIGNATURE_FLAGS d3d12_flags;
+    unsigned int flags; /* vkd3d_root_signature_flag */
 
     unsigned int binding_count;
     struct vkd3d_shader_resource_binding *bindings;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -705,6 +705,7 @@ enum vkd3d_root_descriptor_table_flag
 enum vkd3d_root_signature_flag
 {
     VKD3D_ROOT_SIGNATURE_USE_PUSH_DESCRIPTORS     = 0x00000001u,
+    VKD3D_ROOT_SIGNATURE_USE_INLINE_UNIFORM_BLOCK = 0x00000002u,
 };
 
 struct d3d12_root_descriptor_table
@@ -775,6 +776,7 @@ struct d3d12_root_signature
 
     /* Use one global push constant range */
     VkPushConstantRange push_constant_range;
+    struct vkd3d_shader_descriptor_binding push_constant_ubo_binding;
 
     uint32_t descriptor_table_offset;
     uint32_t descriptor_table_count;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -756,7 +756,7 @@ struct d3d12_root_signature
     uint64_t root_constant_mask;
     uint64_t root_descriptor_mask;
 
-    D3D12_ROOT_SIGNATURE_FLAGS flags;
+    D3D12_ROOT_SIGNATURE_FLAGS d3d12_flags;
 
     unsigned int binding_count;
     struct vkd3d_shader_resource_binding *bindings;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -111,6 +111,7 @@ struct vkd3d_vulkan_info
     bool EXT_debug_marker;
     bool EXT_depth_clip_enable;
     bool EXT_descriptor_indexing;
+    bool EXT_inline_uniform_block;
     bool EXT_shader_demote_to_helper_invocation;
     bool EXT_texel_buffer_alignment;
     bool EXT_transform_feedback;
@@ -1225,6 +1226,7 @@ struct vkd3d_physical_device_info
 {
     /* properties */
     VkPhysicalDeviceDescriptorIndexingPropertiesEXT descriptor_indexing_properties;
+    VkPhysicalDeviceInlineUniformBlockPropertiesEXT inline_uniform_block_properties;
     VkPhysicalDeviceMaintenance3Properties maintenance3_properties;
     VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT texel_buffer_alignment_properties;
     VkPhysicalDeviceTransformFeedbackPropertiesEXT xfb_properties;
@@ -1237,6 +1239,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceDepthClipEnableFeaturesEXT depth_clip_features;
     VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptor_indexing_features;
     VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT demote_features;
+    VkPhysicalDeviceInlineUniformBlockFeaturesEXT inline_uniform_block_features;
     VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT texel_buffer_alignment_features;
     VkPhysicalDeviceTransformFeedbackFeaturesEXT xfb_features;
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT vertex_divisor_features;


### PR DESCRIPTION
We still use push constants if the total size of the root constants and descriptor table offsets is less than the device's maximum push constant size. Passes `test_bindless_full_root_parameters_sm51` on AMD drivers.

Further work is needed to make the root constant layout spec-compliant, but this is not a new issue and is already present in the push constant path.