### PR TITLE
Split descriptor pool allocation based on usage.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -1358,7 +1358,7 @@ static VkDescriptorPool d3d12_command_allocator_allocate_descriptor_pool(
         pool_desc.pPoolSizes = pool_sizes;
 
         if (!device->vk_info.EXT_inline_uniform_block ||
-                device->vk_info.device_limits.maxPushConstantsSize >= D3D12_MAX_ROOT_COST)
+                device->vk_info.device_limits.maxPushConstantsSize >= (D3D12_MAX_ROOT_COST * sizeof(uint32_t)))
         {
             pool_desc.pNext = NULL;
             pool_desc.poolSizeCount -= 1;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -285,7 +285,7 @@ static enum vkd3d_shader_descriptor_type vkd3d_descriptor_type_from_d3d12_root_p
 
 static HRESULT vkd3d_create_descriptor_set_layout(struct d3d12_device *device,
         VkDescriptorSetLayoutCreateFlags flags, unsigned int binding_count,
-        const VkDescriptorSetLayoutBinding *bindings, VkDescriptorSetLayout *set_layout)
+        const VkDescriptorSetLayoutBinding *bindings, VkDescriptorSetLayout *set_layout, bool need_volatile_descriptors)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags_info;
@@ -300,8 +300,7 @@ static HRESULT vkd3d_create_descriptor_set_layout(struct d3d12_device *device,
     set_desc.bindingCount = binding_count;
     set_desc.pBindings = bindings;
 
-    if (device->vk_info.supports_volatile_packed_descriptors &&
-        (flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR) == 0)
+    if (need_volatile_descriptors && device->vk_info.supports_volatile_packed_descriptors)
     {
         set_desc.flags |= VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT;
         flags_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT;
@@ -711,7 +710,7 @@ static HRESULT d3d12_root_signature_init_root_descriptor_tables(struct d3d12_roo
 
     if (info->descriptor_count)
         hr = vkd3d_create_descriptor_set_layout(root_signature->device, 0,
-                info->descriptor_count, vk_binding_info, vk_set_layout);
+                info->descriptor_count, vk_binding_info, vk_set_layout, true);
     else
         hr = S_OK;
 
@@ -796,7 +795,7 @@ static HRESULT d3d12_root_signature_init_root_descriptors(struct d3d12_root_sign
             ? VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR : 0;
 
     hr = vkd3d_create_descriptor_set_layout(root_signature->device, vk_flags,
-            j, vk_binding_info, vk_set_layout);
+            j, vk_binding_info, vk_set_layout, false);
 
     vkd3d_free(vk_binding_info);
     return hr;
@@ -848,7 +847,7 @@ static HRESULT d3d12_root_signature_init_static_samplers(struct d3d12_root_signa
     }
 
     hr = vkd3d_create_descriptor_set_layout(root_signature->device, 0,
-            desc->NumStaticSamplers, vk_binding_info, vk_set_layout);
+            desc->NumStaticSamplers, vk_binding_info, vk_set_layout, false);
 
 cleanup:
     vkd3d_free(vk_binding_info);
@@ -3082,7 +3081,7 @@ HRESULT vkd3d_uav_clear_state_init(struct vkd3d_uav_clear_state *state, struct d
     {
         set_binding.descriptorType = set_layouts[i].descriptor_type;
 
-        if (FAILED(hr = vkd3d_create_descriptor_set_layout(device, 0, 1, &set_binding, set_layouts[i].set_layout)))
+        if (FAILED(hr = vkd3d_create_descriptor_set_layout(device, 0, 1, &set_binding, set_layouts[i].set_layout, false)))
         {
             ERR("Failed to create descriptor set layout %u, hr %#x.", i, hr);
             goto fail;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -896,6 +896,26 @@ struct vkd3d_buffer
     VkDeviceMemory vk_memory;
 };
 
+struct d3d12_descriptor_pool_cache
+{
+    VkDescriptorPool vk_descriptor_pool;
+    VkDescriptorPool *free_descriptor_pools;
+    size_t free_descriptor_pools_size;
+    size_t free_descriptor_pool_count;
+
+    VkDescriptorPool *descriptor_pools;
+    size_t descriptor_pools_size;
+    size_t descriptor_pool_count;
+};
+
+enum vkd3d_descriptor_pool_types
+{
+    VKD3D_DESCRIPTOR_POOL_TYPE_STATIC = 0,
+    VKD3D_DESCRIPTOR_POOL_TYPE_VOLATILE,
+    VKD3D_DESCRIPTOR_POOL_TYPE_IMMUTABLE_SAMPLER,
+    VKD3D_DESCRIPTOR_POOL_TYPE_COUNT
+};
+
 /* ID3D12CommandAllocator */
 struct d3d12_command_allocator
 {
@@ -907,11 +927,7 @@ struct d3d12_command_allocator
 
     VkCommandPool vk_command_pool;
 
-    VkDescriptorPool vk_descriptor_pool;
-
-    VkDescriptorPool *free_descriptor_pools;
-    size_t free_descriptor_pools_size;
-    size_t free_descriptor_pool_count;
+    struct d3d12_descriptor_pool_cache descriptor_pool_caches[VKD3D_DESCRIPTOR_POOL_TYPE_COUNT];
 
     VkRenderPass *passes;
     size_t passes_size;
@@ -920,10 +936,6 @@ struct d3d12_command_allocator
     VkFramebuffer *framebuffers;
     size_t framebuffers_size;
     size_t framebuffer_count;
-
-    VkDescriptorPool *descriptor_pools;
-    size_t descriptor_pools_size;
-    size_t descriptor_pool_count;
 
     struct vkd3d_view **views;
     size_t views_size;


### PR DESCRIPTION
Avoids a potential issue where root descriptors and other static descriptors were being allocated as UPDATE_AFTER_BIND, which could lead to more pressure on maxUpdateAfterBindDescriptors limit.