### PR TITLE
vkd3d: Implement bindless CBV using SSBOs if necessary

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -174,6 +174,7 @@ struct vkd3d_shader_descriptor_table_buffer
 enum vkd3d_shader_interface_flag
 {
     VKD3D_SHADER_INTERFACE_PUSH_CONSTANTS_AS_UNIFORM_BUFFER = 0x00000001u,
+    VKD3D_SHADER_INTERFACE_BINDLESS_CBV_AS_STORAGE_BUFFER   = 0x00000002u,
 };
 
 struct vkd3d_shader_interface_info

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1491,11 +1491,6 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
     {
         descriptor_indexing->shaderInputAttachmentArrayDynamicIndexing = VK_FALSE;
         descriptor_indexing->shaderInputAttachmentArrayNonUniformIndexing = VK_FALSE;
-
-        /* We do not use storage buffers currently. */
-        features->shaderStorageBufferArrayDynamicIndexing = VK_FALSE;
-        descriptor_indexing->shaderStorageBufferArrayNonUniformIndexing = VK_FALSE;
-        descriptor_indexing->descriptorBindingStorageBufferUpdateAfterBind = VK_FALSE;
     }
 
     if (vulkan_info->EXT_descriptor_indexing && descriptor_indexing

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2730,7 +2730,7 @@ void d3d12_desc_create_cbv(struct d3d12_desc *descriptor,
     }
 
     descriptor->magic = VKD3D_DESCRIPTOR_MAGIC_CBV;
-    descriptor->vk_descriptor_type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    descriptor->vk_descriptor_type = vkd3d_bindless_state_get_cbv_descriptor_type(&device->bindless_state);
 }
 
 static unsigned int vkd3d_view_flags_from_d3d12_buffer_srv_flags(D3D12_BUFFER_SRV_FLAGS flags)
@@ -3697,7 +3697,7 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_pool(struct d3d12_descrip
         if (set_info->heap_type == descriptor_heap->desc.Type)
         {
             VkDescriptorPoolSize *vk_pool_size = &vk_pool_sizes[pool_count++];
-            vk_pool_size->type = vk_descriptor_type_from_bindless_set_info(set_info);
+            vk_pool_size->type = set_info->vk_descriptor_type;
             vk_pool_size->descriptorCount = descriptor_heap->desc.NumDescriptors;
         }
     }

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -824,6 +824,7 @@ HRESULT vkd3d_create_buffer(struct d3d12_device *device,
     buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT
             | VK_BUFFER_USAGE_TRANSFER_DST_BIT
             | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
+            | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
             | VK_BUFFER_USAGE_INDEX_BUFFER_BIT
             | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
             | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2866,18 +2866,23 @@ static uint32_t vkd3d_bindless_state_get_bindless_flags(struct d3d12_device *dev
     if (!vk_info->EXT_descriptor_indexing ||
             !device_info->descriptor_indexing_features.runtimeDescriptorArray ||
             !device_info->descriptor_indexing_features.descriptorBindingPartiallyBound ||
+            !device_info->descriptor_indexing_features.descriptorBindingUpdateUnusedWhilePending ||
             !device_info->descriptor_indexing_features.descriptorBindingVariableDescriptorCount)
         return 0;
 
     if (device_info->descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindSampledImages >= 1000000 &&
+            device_info->descriptor_indexing_features.descriptorBindingSampledImageUpdateAfterBind &&
+            device_info->descriptor_indexing_features.descriptorBindingUniformTexelBufferUpdateAfterBind &&
             device_info->descriptor_indexing_features.shaderSampledImageArrayNonUniformIndexing &&
             device_info->descriptor_indexing_features.shaderUniformTexelBufferArrayNonUniformIndexing)
         flags |= VKD3D_BINDLESS_SAMPLER | VKD3D_BINDLESS_SRV;
 
     if (device_info->descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindUniformBuffers >= 1000000 &&
+            device_info->descriptor_indexing_features.descriptorBindingUniformBufferUpdateAfterBind &&
             device_info->descriptor_indexing_features.shaderUniformBufferArrayNonUniformIndexing)
         flags |= VKD3D_BINDLESS_CBV;
     else if (device_info->descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindStorageBuffers >= 1000000 &&
+            device_info->descriptor_indexing_features.descriptorBindingStorageBufferUpdateAfterBind &&
             device_info->descriptor_indexing_features.shaderStorageBufferArrayNonUniformIndexing)
         flags |= VKD3D_BINDLESS_CBV | VKD3D_BINDLESS_CBV_AS_SSBO;
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -1044,6 +1044,9 @@ static unsigned int d3d12_root_signature_get_shader_interface_flags(const struct
     if (root_signature->flags & VKD3D_ROOT_SIGNATURE_USE_INLINE_UNIFORM_BLOCK)
         flags |= VKD3D_SHADER_INTERFACE_PUSH_CONSTANTS_AS_UNIFORM_BUFFER;
 
+    if (root_signature->device->bindless_state.flags & VKD3D_BINDLESS_CBV_AS_SSBO)
+        flags |= VKD3D_SHADER_INTERFACE_BINDLESS_CBV_AS_STORAGE_BUFFER;
+
     return flags;
 }
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2877,6 +2877,9 @@ static uint32_t vkd3d_bindless_state_get_bindless_flags(struct d3d12_device *dev
     if (device_info->descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindUniformBuffers >= 1000000 &&
             device_info->descriptor_indexing_features.shaderUniformBufferArrayNonUniformIndexing)
         flags |= VKD3D_BINDLESS_CBV;
+    else if (device_info->descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindStorageBuffers >= 1000000 &&
+            device_info->descriptor_indexing_features.shaderStorageBufferArrayNonUniformIndexing)
+        flags |= VKD3D_BINDLESS_CBV | VKD3D_BINDLESS_CBV_AS_SSBO;
 
     return flags;
 }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1163,6 +1163,7 @@ enum vkd3d_bindless_flags
     VKD3D_BINDLESS_CBV          = (1u << 1),
     VKD3D_BINDLESS_SRV          = (1u << 2),
     VKD3D_BINDLESS_UAV          = (1u << 3),
+    VKD3D_BINDLESS_CBV_AS_SSBO  = (1u << 4),
 };
 
 struct vkd3d_bindless_set_info

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1168,6 +1168,7 @@ enum vkd3d_bindless_flags
 
 struct vkd3d_bindless_set_info
 {
+    VkDescriptorType vk_descriptor_type;
     D3D12_DESCRIPTOR_HEAP_TYPE heap_type;
     D3D12_DESCRIPTOR_RANGE_TYPE range_type;
     enum vkd3d_shader_binding_flag binding_flag;
@@ -1191,7 +1192,12 @@ bool vkd3d_bindless_state_find_binding(const struct vkd3d_bindless_state *bindle
         D3D12_DESCRIPTOR_RANGE_TYPE range_type, enum vkd3d_shader_binding_flag binding_flag,
         struct vkd3d_shader_descriptor_binding *binding) DECLSPEC_HIDDEN;
 
-VkDescriptorType vk_descriptor_type_from_bindless_set_info(const struct vkd3d_bindless_set_info *set_info) DECLSPEC_HIDDEN;
+inline VkDescriptorType vkd3d_bindless_state_get_cbv_descriptor_type(const struct vkd3d_bindless_state *bindless_state)
+{
+    return bindless_state->flags & VKD3D_BINDLESS_CBV_AS_SSBO
+            ? VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+            : VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+}
 
 struct vkd3d_format_compatibility_list
 {


### PR DESCRIPTION
Older Nvidia generations up to Pascal don't support bindless uniform buffers.

Note that we don't expose `RESOURCE_BINDING_TIER_3` just yet on those GPUs since the code to determine d3d12 caps should probably be reworked as well. What should we check for?

Maybe something like the following:
- No bindless -> Tier 1
- Bindless SRV+Samplers -> Tier 2
- Bindless everything -> Tier 3