### PR TITLE
vkd3d: Fix barriers for bindless CBV-as-SSBO.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -1936,8 +1936,8 @@ static void d3d12_command_list_invalidate_root_parameters(struct d3d12_command_l
     }
 }
 
-static bool vk_barrier_parameters_from_d3d12_resource_state(unsigned int state, unsigned int stencil_state,
-        const struct d3d12_resource *resource, VkQueueFlags vk_queue_flags, const struct vkd3d_vulkan_info *vk_info,
+static bool vk_barrier_parameters_from_d3d12_resource_state(struct d3d12_device *device, unsigned int state,
+        unsigned int stencil_state, const struct d3d12_resource *resource, VkQueueFlags vk_queue_flags,
         VkAccessFlags *access_mask, VkPipelineStageFlags *stage_flags, VkImageLayout *image_layout)
 {
     bool is_swapchain_image = resource && (resource->flags & VKD3D_RESOURCE_PRESENT_STATE_TRANSITION);
@@ -1975,8 +1975,8 @@ static bool vk_barrier_parameters_from_d3d12_resource_state(unsigned int state, 
                 }
                 else if (resource->present_state != D3D12_RESOURCE_STATE_COMMON)
                 {
-                    vk_barrier_parameters_from_d3d12_resource_state(resource->present_state, 0,
-                            resource, vk_queue_flags, vk_info, access_mask, stage_flags, image_layout);
+                    vk_barrier_parameters_from_d3d12_resource_state(device, resource->present_state, 0,
+                            resource, vk_queue_flags, access_mask, stage_flags, image_layout);
                     return true;
                 }
             }
@@ -2089,6 +2089,10 @@ static bool vk_barrier_parameters_from_d3d12_resource_state(unsigned int state, 
     {
         *access_mask |= VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT
                 | VK_ACCESS_UNIFORM_READ_BIT;
+
+        if (device->bindless_state.flags & VKD3D_BINDLESS_CBV_AS_SSBO)
+            *access_mask |= VK_ACCESS_SHADER_READ_BIT;
+
         *stage_flags |= VK_PIPELINE_STAGE_VERTEX_INPUT_BIT
                 | queue_shader_stages;
         state &= ~D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
@@ -2126,7 +2130,7 @@ static bool vk_barrier_parameters_from_d3d12_resource_state(unsigned int state, 
     {
         *access_mask |= VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
         *stage_flags |= VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT;
-        if (vk_info->EXT_conditional_rendering)
+        if (device->vk_info.EXT_conditional_rendering)
         {
             *access_mask |= VK_ACCESS_CONDITIONAL_RENDERING_READ_BIT_EXT;
             *stage_flags |= VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT;
@@ -2153,7 +2157,6 @@ static void d3d12_command_list_transition_resource_to_initial_state(struct d3d12
         struct d3d12_resource *resource)
 {
     const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
-    const struct vkd3d_vulkan_info *vk_info = &list->device->vk_info;
     VkPipelineStageFlags src_stage_mask, dst_stage_mask;
     const struct vkd3d_format *format;
     VkImageMemoryBarrier barrier;
@@ -2175,8 +2178,8 @@ static void d3d12_command_list_transition_resource_to_initial_state(struct d3d12
     barrier.oldLayout = d3d12_resource_is_cpu_accessible(resource) ?
             VK_IMAGE_LAYOUT_PREINITIALIZED : VK_IMAGE_LAYOUT_UNDEFINED;
 
-    if (!vk_barrier_parameters_from_d3d12_resource_state(resource->initial_state, 0,
-            resource, list->vk_queue_flags, vk_info, &barrier.dstAccessMask, &dst_stage_mask, &barrier.newLayout))
+    if (!vk_barrier_parameters_from_d3d12_resource_state(list->device, resource->initial_state, 0,
+            resource, list->vk_queue_flags, &barrier.dstAccessMask, &dst_stage_mask, &barrier.newLayout))
     {
         FIXME("Unhandled state %#x.\n", resource->initial_state);
         return;
@@ -4049,16 +4052,12 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResourceBarrier(ID3D12GraphicsC
         UINT barrier_count, const D3D12_RESOURCE_BARRIER *barriers)
 {
     struct d3d12_command_list *list = impl_from_ID3D12GraphicsCommandList2(iface);
+    const struct vkd3d_vk_device_procs *vk_procs = &list->device->vk_procs;
     bool have_aliasing_barriers = false, have_split_barriers = false;
-    const struct vkd3d_vk_device_procs *vk_procs;
-    const struct vkd3d_vulkan_info *vk_info;
     bool *multiplanar_handled = NULL;
     unsigned int i;
 
     TRACE("iface %p, barrier_count %u, barriers %p.\n", iface, barrier_count, barriers);
-
-    vk_procs = &list->device->vk_procs;
-    vk_info = &list->device->vk_info;
 
     d3d12_command_list_end_current_render_pass(list);
 
@@ -4143,14 +4142,14 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResourceBarrier(ID3D12GraphicsC
                     }
                 }
 
-                if (!vk_barrier_parameters_from_d3d12_resource_state(state_before, stencil_state_before,
-                        resource, list->vk_queue_flags, vk_info, &src_access_mask, &src_stage_mask, &layout_before))
+                if (!vk_barrier_parameters_from_d3d12_resource_state(list->device, state_before, stencil_state_before,
+                        resource, list->vk_queue_flags, &src_access_mask, &src_stage_mask, &layout_before))
                 {
                     FIXME("Unhandled state %#x.\n", state_before);
                     continue;
                 }
-                if (!vk_barrier_parameters_from_d3d12_resource_state(state_after, stencil_state_after,
-                        resource, list->vk_queue_flags, vk_info, &dst_access_mask, &dst_stage_mask, &layout_after))
+                if (!vk_barrier_parameters_from_d3d12_resource_state(list->device, state_after, stencil_state_after,
+                        resource, list->vk_queue_flags, &dst_access_mask, &dst_stage_mask, &layout_after))
                 {
                     FIXME("Unhandled state %#x.\n", state_after);
                     continue;
@@ -4169,8 +4168,8 @@ static void STDMETHODCALLTYPE d3d12_command_list_ResourceBarrier(ID3D12GraphicsC
                 VkAccessFlags access_mask;
 
                 resource = unsafe_impl_from_ID3D12Resource(uav->pResource);
-                vk_barrier_parameters_from_d3d12_resource_state(D3D12_RESOURCE_STATE_UNORDERED_ACCESS, 0,
-                        resource, list->vk_queue_flags, vk_info, &access_mask, &stage_mask, &image_layout);
+                vk_barrier_parameters_from_d3d12_resource_state(list->device, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, 0,
+                        resource, list->vk_queue_flags, &access_mask, &stage_mask, &image_layout);
                 src_access_mask = dst_access_mask = access_mask;
                 src_stage_mask = dst_stage_mask = stage_mask;
                 layout_before = layout_after = image_layout;


### PR DESCRIPTION
Title. For SSBO we need `VK_ACCESS_SHADER_READ_BIT`.