### PR TITLE
vkd3d: Bindless UAV

### DIFF
--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -8425,6 +8425,9 @@ static void vkd3d_dxbc_compiler_emit_atomic_instruction(struct vkd3d_dxbc_compil
         sample_id = vkd3d_dxbc_compiler_get_constant_uint(compiler, 0);
         pointer_id = vkd3d_spirv_build_op_image_texel_pointer(builder,
                 ptr_type_id, image.id, coordinate_id, sample_id);
+
+        if (resource->reg.modifier == VKD3DSPRM_NONUNIFORM)
+            vkd3d_dxbc_compiler_decorate_nonuniform(compiler, pointer_id);
     }
 
     val_id = vkd3d_dxbc_compiler_emit_load_src_with_type(compiler, &src[1], VKD3DSP_WRITEMASK_0, component_type);

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -5013,8 +5013,9 @@ static void vkd3d_dxbc_compiler_emit_hull_shader_patch_constants(struct vkd3d_dx
 
 static const struct vkd3d_shader_global_binding *vkd3d_dxbc_compiler_get_global_binding(struct vkd3d_dxbc_compiler *compiler,
         enum vkd3d_data_type data_type, enum vkd3d_shader_resource_type resource_type, enum vkd3d_component_type component_type,
-        SpvStorageClass storage_class, const struct vkd3d_shader_descriptor_binding* binding_info)
+        SpvStorageClass storage_class, const struct vkd3d_shader_resource_binding* binding)
 {
+    const struct vkd3d_shader_descriptor_binding *binding_info = &binding->binding;
     struct vkd3d_spirv_builder *builder = &compiler->spirv_builder;
     struct vkd3d_shader_global_binding *current;
     uint32_t array_type_id, type_id, var_id;
@@ -5411,7 +5412,7 @@ static void vkd3d_dxbc_compiler_emit_dcl_constant_buffer(struct vkd3d_dxbc_compi
     {
         global_binding = vkd3d_dxbc_compiler_get_global_binding(compiler,
                 VKD3D_DATA_FLOAT, VKD3D_SHADER_RESOURCE_BUFFER,
-                VKD3D_TYPE_FLOAT, storage_class, &binding->binding);
+                VKD3D_TYPE_FLOAT, storage_class, binding);
 
         var_id = global_binding->var_id;
     }
@@ -5506,7 +5507,7 @@ static void vkd3d_dxbc_compiler_emit_dcl_sampler(struct vkd3d_dxbc_compiler *com
     if (binding && (binding->flags & VKD3D_SHADER_BINDING_FLAG_BINDLESS))
     {
         global_binding = vkd3d_dxbc_compiler_get_global_binding(compiler, VKD3D_DATA_SAMPLER,
-                VKD3D_SHADER_RESOURCE_NONE, VKD3D_TYPE_VOID, storage_class, &binding->binding);
+                VKD3D_SHADER_RESOURCE_NONE, VKD3D_TYPE_VOID, storage_class, binding);
 
         var_id = global_binding->var_id;
     }
@@ -5637,7 +5638,7 @@ static void vkd3d_dxbc_compiler_emit_resource_declaration(struct vkd3d_dxbc_comp
     {
         global_binding = vkd3d_dxbc_compiler_get_global_binding(compiler,
                 is_uav ? VKD3D_DATA_UAV : VKD3D_DATA_RESOURCE, resource_type,
-                sampled_type, storage_class, &binding->binding);
+                sampled_type, storage_class, binding);
 
         type_id = global_binding->type_id;
         var_id = global_binding->var_id;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2906,6 +2906,13 @@ static uint32_t vkd3d_bindless_state_get_bindless_flags(struct d3d12_device *dev
             device_info->descriptor_indexing_features.shaderUniformTexelBufferArrayNonUniformIndexing)
         flags |= VKD3D_BINDLESS_SAMPLER | VKD3D_BINDLESS_SRV;
 
+    if (device_info->descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindStorageImages >= 1000000 &&
+            device_info->descriptor_indexing_features.descriptorBindingStorageImageUpdateAfterBind &&
+            device_info->descriptor_indexing_features.descriptorBindingStorageTexelBufferUpdateAfterBind &&
+            device_info->descriptor_indexing_features.shaderStorageImageArrayNonUniformIndexing &&
+            device_info->descriptor_indexing_features.shaderStorageTexelBufferArrayNonUniformIndexing)
+        flags |= VKD3D_BINDLESS_UAV;
+
 #if 0
     /* NVIDIA drivers currently (as of 2020-03-25) seem to have some rather interesting issues with bindless UBO where bindless SSBO
      * appears to work just fine. AMD does not care about UBO vs SSBO, so just use bindless SSBO until the issues are resolved. */

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -693,6 +693,7 @@ static HRESULT d3d12_root_signature_init_root_descriptor_tables(struct d3d12_roo
                         vk_binding.stageFlags = stage_flags_from_visibility(p->ShaderVisibility);
                         vk_binding.pImmutableSamplers = NULL;
 
+                        binding.binding.set = context->vk_set;
                         binding.register_index = range->BaseShaderRegister + k;
                         binding.register_count = 1;
                         binding.descriptor_offset = range_descriptor_offset + k;


### PR DESCRIPTION
Passes the bindless UAV test *without* counters on both RADV and AMDVLK.

We currently completely ignore UAV counters for unbounded UAV descriptor ranges in order to avoid out of memory errors. This is not a regression as unbounded UAV descriptor ranges were completely unsupported before.