### PR TITLE
vkd3d: Bindless UAV counters

### DIFF
--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -1743,6 +1743,7 @@ static const vkd3d_spirv_capability_extensions[] =
 static bool vkd3d_spirv_compile_module(struct vkd3d_spirv_builder *builder,
         struct vkd3d_shader_code *spirv)
 {
+    SpvAddressingModel addressing_model;
     struct vkd3d_spirv_stream stream;
     uint32_t extension_mask = 0;
     unsigned int i, j;
@@ -1785,7 +1786,12 @@ static bool vkd3d_spirv_compile_module(struct vkd3d_spirv_builder *builder,
         vkd3d_spirv_build_op_ext_inst_import(&stream, builder->ext_instr_set_glsl_450, "GLSL.std.450");
 
     /* entry point declarations */
-    vkd3d_spirv_build_op_memory_model(&stream, SpvAddressingModelLogical, SpvMemoryModelGLSL450);
+    addressing_model = SpvAddressingModelLogical;
+
+    if (vkd3d_spirv_has_capability(builder, SpvCapabilityPhysicalStorageBufferAddresses))
+        addressing_model = SpvAddressingModelPhysicalStorageBuffer64;
+
+    vkd3d_spirv_build_op_memory_model(&stream, addressing_model, SpvMemoryModelGLSL450);
     vkd3d_spirv_build_op_entry_point(&stream, builder->execution_model, builder->main_function_id,
             "main", builder->iface, builder->iface_element_count);
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -143,6 +143,7 @@ static const char * const required_device_extensions[] =
 static const struct vkd3d_optional_extension_info optional_device_extensions[] =
 {
     /* KHR extensions */
+    VK_EXTENSION(KHR_BUFFER_DEVICE_ADDRESS, KHR_buffer_device_address),
     VK_EXTENSION(KHR_DEDICATED_ALLOCATION, KHR_dedicated_allocation),
     VK_EXTENSION(KHR_DRAW_INDIRECT_COUNT, KHR_draw_indirect_count),
     VK_EXTENSION(KHR_GET_MEMORY_REQUIREMENTS_2, KHR_get_memory_requirements2),
@@ -696,6 +697,7 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
 {
     const struct vkd3d_vk_instance_procs *vk_procs = &device->vkd3d_instance->vk_procs;
     VkPhysicalDeviceInlineUniformBlockPropertiesEXT *inline_uniform_block_properties;
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR *buffer_device_address_features;
     VkPhysicalDeviceConditionalRenderingFeaturesEXT *conditional_rendering_features;
     VkPhysicalDeviceDescriptorIndexingPropertiesEXT *descriptor_indexing_properties;
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT *vertex_divisor_properties;
@@ -714,6 +716,7 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     struct vkd3d_vulkan_info *vulkan_info = &device->vk_info;
 
     memset(info, 0, sizeof(*info));
+    buffer_device_address_features = &info->buffer_device_address_features;
     conditional_rendering_features = &info->conditional_rendering_features;
     depth_clip_features = &info->depth_clip_features;
     descriptor_indexing_features = &info->descriptor_indexing_features;
@@ -732,6 +735,8 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
 
     info->features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 
+    buffer_device_address_features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR;
+    vk_prepend_struct(&info->features2, buffer_device_address_features);
     conditional_rendering_features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT;
     vk_prepend_struct(&info->features2, conditional_rendering_features);
     depth_clip_features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -829,6 +829,9 @@ HRESULT vkd3d_create_buffer(struct d3d12_device *device,
             | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
             | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
 
+    if (device->device_info.buffer_device_address_features.bufferDeviceAddress)
+        buffer_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
+
     if (device->vk_info.EXT_conditional_rendering)
         buffer_info.usage |= VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT;
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3766,6 +3766,51 @@ static HRESULT d3d12_descriptor_heap_create_descriptor_set(struct d3d12_descript
     return S_OK;
 }
 
+static HRESULT d3d12_descriptor_heap_create_uav_counter_buffer(struct d3d12_descriptor_heap *descriptor_heap,
+        struct d3d12_descriptor_heap_uav_counters *uav_counters)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &descriptor_heap->device->vk_procs;
+    struct d3d12_device *device = descriptor_heap->device;
+    D3D12_HEAP_PROPERTIES heap_info;
+    D3D12_RESOURCE_DESC buffer_desc;
+    D3D12_HEAP_FLAGS heap_flags;
+    VkResult vr;
+    HRESULT hr;
+
+    /* concurrently accessible storage buffer */
+    memset(&buffer_desc, 0, sizeof(buffer_desc));
+    buffer_desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+    buffer_desc.Width = descriptor_heap->desc.NumDescriptors * sizeof(VkDeviceAddress);
+    buffer_desc.Height = 1;
+    buffer_desc.DepthOrArraySize = 1;
+    buffer_desc.MipLevels = 1;
+    buffer_desc.SampleDesc.Count = 1;
+    buffer_desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+    buffer_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+
+    /* host-visible device memory */
+    memset(&heap_info, 0, sizeof(heap_info));
+    heap_info.Type = D3D12_HEAP_TYPE_UPLOAD;
+
+    heap_flags = D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
+
+    if (FAILED(hr = vkd3d_create_buffer(device, &heap_info, heap_flags, &buffer_desc, &uav_counters->vk_buffer)))
+        return hr;
+
+    if (FAILED(hr = vkd3d_allocate_buffer_memory(device, uav_counters->vk_buffer,
+            &heap_info, heap_flags, &uav_counters->vk_memory, NULL, NULL)))
+        return hr;
+
+    if ((vr = VK_CALL(vkMapMemory(device->vk_device, uav_counters->vk_memory,
+            0, VK_WHOLE_SIZE, 0, (void **)&uav_counters->data))))
+    {
+        ERR("Failed to map UAV counter address buffer, vr %d.\n", vr);
+        return hresult_from_vk_result(vr);
+    }
+
+    return S_OK;
+}
+
 static HRESULT d3d12_descriptor_heap_init(struct d3d12_descriptor_heap *descriptor_heap,
         struct d3d12_device *device, const D3D12_DESCRIPTOR_HEAP_DESC *desc)
 {
@@ -3796,6 +3841,14 @@ static HRESULT d3d12_descriptor_heap_init(struct d3d12_descriptor_heap *descript
                         set_info, &descriptor_heap->vk_descriptor_sets[set_index])))
                     goto fail;
             }
+        }
+
+        if (desc->Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV &&
+                (device->bindless_state.flags & VKD3D_BINDLESS_UAV_COUNTER))
+        {
+            if (FAILED(hr = d3d12_descriptor_heap_create_uav_counter_buffer(descriptor_heap,
+                    &descriptor_heap->uav_counters)))
+                goto fail;
         }
     }
 
@@ -3891,8 +3944,10 @@ void d3d12_descriptor_heap_cleanup(struct d3d12_descriptor_heap *descriptor_heap
     const struct vkd3d_vk_device_procs *vk_procs = &descriptor_heap->device->vk_procs;
     const struct d3d12_device *device = descriptor_heap->device;
 
-    VK_CALL(vkDestroyDescriptorPool(device->vk_device,
-            descriptor_heap->vk_descriptor_pool, NULL));
+    VK_CALL(vkDestroyBuffer(device->vk_device, descriptor_heap->uav_counters.vk_buffer, NULL));
+    VK_CALL(vkFreeMemory(device->vk_device, descriptor_heap->uav_counters.vk_memory, NULL));
+
+    VK_CALL(vkDestroyDescriptorPool(device->vk_device, descriptor_heap->vk_descriptor_pool, NULL));
 }
 
 unsigned int d3d12_descriptor_heap_set_index_from_binding(const struct vkd3d_bindless_set_info *set)

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -837,9 +837,6 @@ HRESULT vkd3d_create_buffer(struct d3d12_device *device,
             | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
             | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
 
-    if (device->device_info.buffer_device_address_features.bufferDeviceAddress)
-        buffer_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
-
     if (device->vk_info.EXT_conditional_rendering)
         buffer_info.usage |= VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT;
 
@@ -855,7 +852,13 @@ HRESULT vkd3d_create_buffer(struct d3d12_device *device,
         buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
     if (desc->Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
+    {
         buffer_info.usage |= VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
+
+        if (device->device_info.buffer_device_address_features.bufferDeviceAddress)
+            buffer_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
+    }
+
     if (!(desc->Flags & D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE))
         buffer_info.usage |= VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2950,6 +2950,9 @@ static uint32_t vkd3d_bindless_state_get_bindless_flags(struct d3d12_device *dev
             device_info->descriptor_indexing_features.shaderStorageBufferArrayNonUniformIndexing)
         flags |= VKD3D_BINDLESS_CBV | VKD3D_BINDLESS_CBV_AS_SSBO;
 
+    if (device_info->buffer_device_address_features.bufferDeviceAddress && (flags & VKD3D_BINDLESS_UAV))
+        flags |= VKD3D_BINDLESS_UAV_COUNTER;
+
     return flags;
 }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -100,6 +100,7 @@ struct vkd3d_vulkan_info
     bool EXT_debug_report;
 
     /* KHR device extensions */
+    bool KHR_buffer_device_address;
     bool KHR_dedicated_allocation;
     bool KHR_draw_indirect_count;
     bool KHR_get_memory_requirements2;
@@ -1262,6 +1263,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceProperties2KHR properties2;
 
     /* features */
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR buffer_device_address_features;
     VkPhysicalDeviceConditionalRenderingFeaturesEXT conditional_rendering_features;
     VkPhysicalDeviceDepthClipEnableFeaturesEXT depth_clip_features;
     VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptor_indexing_features;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -977,6 +977,7 @@ enum vkd3d_pipeline_dirty_flag
     VKD3D_PIPELINE_DIRTY_STATIC_SAMPLER_SET       = 0x00000001u,
     VKD3D_PIPELINE_DIRTY_PACKED_DESCRIPTOR_SET    = 0x00000002u,
     VKD3D_PIPELINE_DIRTY_DESCRIPTOR_TABLE_OFFSETS = 0x00000004u,
+    VKD3D_PIPELINE_DIRTY_UAV_COUNTER_BINDING      = 0x00000008u,
 };
 
 union vkd3d_descriptor_info
@@ -1057,6 +1058,7 @@ struct d3d12_command_list
     VkPipeline current_pipeline;
     VkRenderPass pso_render_pass;
     VkRenderPass current_render_pass;
+    VkBuffer uav_counter_address_buffer;
     struct vkd3d_pipeline_bindings pipeline_bindings[VK_PIPELINE_BIND_POINT_RANGE_SIZE];
     struct vkd3d_descriptor_updates packed_descriptors[VK_PIPELINE_BIND_POINT_RANGE_SIZE];
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -704,8 +704,9 @@ enum vkd3d_root_descriptor_table_flag
 
 enum vkd3d_root_signature_flag
 {
-    VKD3D_ROOT_SIGNATURE_USE_PUSH_DESCRIPTORS     = 0x00000001u,
-    VKD3D_ROOT_SIGNATURE_USE_INLINE_UNIFORM_BLOCK = 0x00000002u,
+    VKD3D_ROOT_SIGNATURE_USE_PUSH_DESCRIPTORS       = 0x00000001u,
+    VKD3D_ROOT_SIGNATURE_USE_INLINE_UNIFORM_BLOCK   = 0x00000002u,
+    VKD3D_ROOT_SIGNATURE_USE_BINDLESS_UAV_COUNTERS  = 0x00000004u,
 };
 
 struct d3d12_root_descriptor_table
@@ -777,6 +778,7 @@ struct d3d12_root_signature
     /* Use one global push constant range */
     VkPushConstantRange push_constant_range;
     struct vkd3d_shader_descriptor_binding push_constant_ubo_binding;
+    struct vkd3d_shader_descriptor_binding uav_counter_binding;
 
     uint32_t descriptor_table_offset;
     uint32_t descriptor_table_count;
@@ -1174,7 +1176,8 @@ enum vkd3d_bindless_flags
     VKD3D_BINDLESS_CBV          = (1u << 1),
     VKD3D_BINDLESS_SRV          = (1u << 2),
     VKD3D_BINDLESS_UAV          = (1u << 3),
-    VKD3D_BINDLESS_CBV_AS_SSBO  = (1u << 4),
+    VKD3D_BINDLESS_UAV_COUNTER  = (1u << 4),
+    VKD3D_BINDLESS_CBV_AS_SSBO  = (1u << 5),
 };
 
 struct vkd3d_bindless_set_info

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -487,6 +487,7 @@ struct vkd3d_view
         VkSampler vk_sampler;
     } u;
     VkBufferView vk_counter_view;
+    VkDeviceAddress vk_counter_address;
     const struct vkd3d_format *format;
     union
     {

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -608,6 +608,13 @@ static inline struct d3d12_dsv_desc *d3d12_dsv_desc_from_cpu_handle(D3D12_CPU_DE
 void d3d12_dsv_desc_create_dsv(struct d3d12_dsv_desc *dsv_desc, struct d3d12_device *device,
         struct d3d12_resource *resource, const D3D12_DEPTH_STENCIL_VIEW_DESC *desc) DECLSPEC_HIDDEN;
 
+struct d3d12_descriptor_heap_uav_counters
+{
+    VkDeviceAddress *data;
+    VkDeviceMemory vk_memory;
+    VkBuffer vk_buffer;
+};
+
 /* ID3D12DescriptorHeap */
 struct d3d12_descriptor_heap
 {
@@ -619,6 +626,7 @@ struct d3d12_descriptor_heap
     VkDescriptorPool vk_descriptor_pool;
     VkDescriptorSet vk_descriptor_sets[VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS];
 
+    struct d3d12_descriptor_heap_uav_counters uav_counters;
     struct d3d12_device *device;
 
     struct vkd3d_private_store private_store;

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -177,6 +177,11 @@ VK_DEVICE_PFN(vkUnmapMemory)
 VK_DEVICE_PFN(vkUpdateDescriptorSets)
 VK_DEVICE_PFN(vkWaitForFences)
 
+/* VK_KHR_buffer_device_address */
+VK_DEVICE_EXT_PFN(vkGetBufferDeviceAddressKHR);
+VK_DEVICE_EXT_PFN(vkGetBufferOpaqueCaptureAddressKHR);
+VK_DEVICE_EXT_PFN(vkGetDeviceMemoryOpaqueCaptureAddressKHR);
+
 /* VK_KHR_draw_indirect_count */
 VK_DEVICE_EXT_PFN(vkCmdDrawIndirectCountKHR)
 VK_DEVICE_EXT_PFN(vkCmdDrawIndexedIndirectCountKHR)


### PR DESCRIPTION
Uses `VK_KHR_buffer_device_address` to pass UAV counter addresses to shaders via an SSBO. This SSBO is part of the root descriptor set in order to avoid complexity around descriptor updates.

Passes `test_bindless_uav_counter_sm51` on RADV.