### PR TITLE
vkd3d: Don't require bindless UAV counters for RESOURCE_BINDING_TIER_3.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3295,7 +3295,7 @@ static const struct ID3D12DeviceVtbl d3d12_device_vtbl =
 static D3D12_RESOURCE_BINDING_TIER d3d12_device_determine_resource_binding_tier(struct d3d12_device *device)
 {
     const uint32_t tier_2_required_flags = VKD3D_BINDLESS_SRV | VKD3D_BINDLESS_SAMPLER;
-    const uint32_t tier_3_required_flags = VKD3D_BINDLESS_CBV | VKD3D_BINDLESS_UAV | VKD3D_BINDLESS_UAV_COUNTER;
+    const uint32_t tier_3_required_flags = VKD3D_BINDLESS_CBV | VKD3D_BINDLESS_UAV;
 
     uint32_t bindless_flags = device->bindless_state.flags;
 


### PR DESCRIPTION
Partially reverts 88437397978ee36fd479d3a8ca94d83e494d6367.

This was a bit premature as Nvidia does not expose VK_KHR_buffer_device_address in current Linux drivers yet, so we're needlessly locking users out of playing some games that work anyway.