### PR TITLE
vkd3d: Fix UAV counter binding declaration.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -707,6 +707,7 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT *vertex_divisor_features;
     VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *buffer_alignment_features;
     VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT *demote_features;
+    VkPhysicalDevicePushDescriptorPropertiesKHR *push_descriptor_properties;
     VkPhysicalDeviceDepthClipEnableFeaturesEXT *depth_clip_features;
     VkPhysicalDeviceMaintenance3Properties *maintenance3_properties;
     VkPhysicalDeviceTransformFeedbackPropertiesEXT *xfb_properties;
@@ -723,6 +724,7 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     descriptor_indexing_properties = &info->descriptor_indexing_properties;
     inline_uniform_block_features = &info->inline_uniform_block_features;
     inline_uniform_block_properties = &info->inline_uniform_block_properties;
+    push_descriptor_properties = &info->push_descriptor_properties;
     maintenance3_properties = &info->maintenance3_properties;
     demote_features = &info->demote_features;
     buffer_alignment_features = &info->texel_buffer_alignment_features;
@@ -765,6 +767,8 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     vk_prepend_struct(&info->properties2, maintenance3_properties);
     descriptor_indexing_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES_EXT;
     vk_prepend_struct(&info->properties2, descriptor_indexing_properties);
+    push_descriptor_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR;
+    vk_prepend_struct(&info->properties2, push_descriptor_properties);
     buffer_alignment_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT;
     vk_prepend_struct(&info->properties2, buffer_alignment_properties);
     xfb_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -817,7 +817,7 @@ static HRESULT d3d12_root_signature_init_root_descriptors(struct d3d12_root_sign
         vk_binding = &vk_binding_info[j++];
         vk_binding->binding = context->vk_binding;
         vk_binding->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        vk_binding->descriptorCount = push_constant_range->size;
+        vk_binding->descriptorCount = 1;
         vk_binding->stageFlags = VK_SHADER_STAGE_ALL;
         vk_binding->pImmutableSamplers = NULL;
 

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -942,7 +942,6 @@ static HRESULT d3d12_root_signature_init(struct d3d12_root_signature *root_signa
     root_signature->binding_count = info.binding_count;
     root_signature->static_sampler_count = desc->NumStaticSamplers;
     root_signature->packed_descriptor_count = info.descriptor_count;
-    root_signature->root_descriptor_count = info.root_descriptor_count;
 
     hr = E_OUTOFMEMORY;
     root_signature->parameter_count = desc->NumParameters;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -783,7 +783,6 @@ struct d3d12_root_signature
     struct vkd3d_shader_push_constant_buffer *root_constants;
 
     unsigned int packed_descriptor_count;
-    unsigned int root_descriptor_count;
 
     /* Use one global push constant range */
     VkPushConstantRange push_constant_range;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1269,6 +1269,7 @@ struct vkd3d_physical_device_info
     /* properties */
     VkPhysicalDeviceDescriptorIndexingPropertiesEXT descriptor_indexing_properties;
     VkPhysicalDeviceInlineUniformBlockPropertiesEXT inline_uniform_block_properties;
+    VkPhysicalDevicePushDescriptorPropertiesKHR push_descriptor_properties;
     VkPhysicalDeviceMaintenance3Properties maintenance3_properties;
     VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT texel_buffer_alignment_properties;
     VkPhysicalDeviceTransformFeedbackPropertiesEXT xfb_properties;


### PR DESCRIPTION
We were accidentally using an incorrect descriptor count.

Also, this checks whether we exceed the device limit for push descriptors and uses the fallback path if we do. This can in theory happen if the root signature has 32 root descriptors and bindless UAV counters are enabled.