### PR TITLE
Implement VK_KHR_timeline_semaphores

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -150,6 +150,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(KHR_IMAGE_FORMAT_LIST, KHR_image_format_list),
     VK_EXTENSION(KHR_MAINTENANCE3, KHR_maintenance3),
     VK_EXTENSION(KHR_PUSH_DESCRIPTOR, KHR_push_descriptor),
+    VK_EXTENSION(KHR_TIMELINE_SEMAPHORE, KHR_timeline_semaphore),
     /* EXT extensions */
     VK_EXTENSION(EXT_CONDITIONAL_RENDERING, EXT_conditional_rendering),
     VK_EXTENSION(EXT_DEBUG_MARKER, EXT_debug_marker),
@@ -702,11 +703,13 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     VkPhysicalDeviceDescriptorIndexingPropertiesEXT *descriptor_indexing_properties;
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT *vertex_divisor_properties;
     VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT *buffer_alignment_properties;
+    VkPhysicalDeviceTimelineSemaphorePropertiesKHR *timeline_semaphore_properties;
     VkPhysicalDeviceInlineUniformBlockFeaturesEXT *inline_uniform_block_features;
     VkPhysicalDeviceDescriptorIndexingFeaturesEXT *descriptor_indexing_features;
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT *vertex_divisor_features;
     VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *buffer_alignment_features;
     VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT *demote_features;
+    VkPhysicalDeviceTimelineSemaphoreFeaturesKHR *timeline_semaphore_features;
     VkPhysicalDevicePushDescriptorPropertiesKHR *push_descriptor_properties;
     VkPhysicalDeviceDepthClipEnableFeaturesEXT *depth_clip_features;
     VkPhysicalDeviceMaintenance3Properties *maintenance3_properties;
@@ -734,6 +737,8 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     xfb_features = &info->xfb_features;
     xfb_properties = &info->xfb_properties;
     subgroup_properties = &info->subgroup_properties;
+    timeline_semaphore_features = &info->timeline_semaphore_features;
+    timeline_semaphore_properties = &info->timeline_semaphore_properties;
 
     info->features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
     info->properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
@@ -745,6 +750,14 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     {
         buffer_device_address_features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR;
         vk_prepend_struct(&info->features2, buffer_device_address_features);
+    }
+
+    if (vulkan_info->KHR_timeline_semaphore)
+    {
+        timeline_semaphore_features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR;
+        vk_prepend_struct(&info->features2, timeline_semaphore_features);
+        timeline_semaphore_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES_KHR;
+        vk_prepend_struct(&info->properties2, timeline_semaphore_properties);
     }
 
     if (vulkan_info->KHR_push_descriptor)

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -358,6 +358,7 @@ struct d3d12_fence
     LONG refcount;
 
     VkSemaphore timeline_semaphore;
+    uint64_t pending_timeline_value;
 
     uint64_t value;
     pthread_mutex_t mutex;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -111,6 +111,7 @@ struct vkd3d_vulkan_info
     bool KHR_image_format_list;
     bool KHR_maintenance3;
     bool KHR_push_descriptor;
+    bool KHR_timeline_semaphore;
     /* EXT device extensions */
     bool EXT_conditional_rendering;
     bool EXT_debug_marker;
@@ -1278,6 +1279,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceTransformFeedbackPropertiesEXT xfb_properties;
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT vertex_divisor_properties;
     VkPhysicalDeviceSubgroupProperties subgroup_properties;
+    VkPhysicalDeviceTimelineSemaphorePropertiesKHR timeline_semaphore_properties;
 
     VkPhysicalDeviceProperties2KHR properties2;
 
@@ -1291,6 +1293,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT texel_buffer_alignment_features;
     VkPhysicalDeviceTransformFeedbackFeaturesEXT xfb_features;
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT vertex_divisor_features;
+    VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timeline_semaphore_features;
 
     VkPhysicalDeviceFeatures2 features2;
 };

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -198,6 +198,7 @@ struct vkd3d_fence_worker
     struct vkd3d_enqueued_fence
     {
         VkFence vk_fence;
+        VkSemaphore vk_semaphore;
         struct vkd3d_waiting_fence waiting_fence;
     } *enqueued_fences;
     size_t enqueued_fences_size;
@@ -207,6 +208,11 @@ struct vkd3d_fence_worker
     size_t vk_fences_size;
     struct vkd3d_waiting_fence *fences;
     size_t fences_size;
+
+    uint64_t *semaphore_wait_values;
+    VkSemaphore *vk_semaphores;
+    size_t vk_semaphores_size;
+    size_t semaphore_wait_values_size;
 
     struct d3d12_device *device;
 };
@@ -350,6 +356,8 @@ struct d3d12_fence
 {
     ID3D12Fence ID3D12Fence_iface;
     LONG refcount;
+
+    VkSemaphore timeline_semaphore;
 
     uint64_t value;
     pthread_mutex_t mutex;

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -182,6 +182,11 @@ VK_DEVICE_EXT_PFN(vkGetBufferDeviceAddressKHR)
 VK_DEVICE_EXT_PFN(vkGetBufferOpaqueCaptureAddressKHR)
 VK_DEVICE_EXT_PFN(vkGetDeviceMemoryOpaqueCaptureAddressKHR)
 
+/* VK_KHR_timeline_semaphore */
+VK_DEVICE_EXT_PFN(vkGetSemaphoreCounterValueKHR)
+VK_DEVICE_EXT_PFN(vkWaitSemaphoresKHR)
+VK_DEVICE_EXT_PFN(vkSignalSemaphoreKHR)
+
 /* VK_KHR_draw_indirect_count */
 VK_DEVICE_EXT_PFN(vkCmdDrawIndirectCountKHR)
 VK_DEVICE_EXT_PFN(vkCmdDrawIndexedIndirectCountKHR)

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -3801,20 +3801,20 @@ static void test_cpu_signal_fence(void)
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == 1, "Got unexpected value %"PRIu64".\n", value);
 
-    hr = ID3D12Fence_Signal(fence, 10);
+    hr = ID3D12Fence_Signal(fence, 2);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     value = ID3D12Fence_GetCompletedValue(fence);
-    ok(value == 10, "Got unexpected value %"PRIu64".\n", value);
+    ok(value == 2, "Got unexpected value %"PRIu64".\n", value);
 
-    hr = ID3D12Fence_Signal(fence, 5);
+    hr = ID3D12Fence_Signal(fence, 3);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     value = ID3D12Fence_GetCompletedValue(fence);
-    ok(value == 5, "Got unexpected value %"PRIu64".\n", value);
+    ok(value == 3, "Got unexpected value %"PRIu64".\n", value);
 
-    hr = ID3D12Fence_Signal(fence, 0);
+    hr = ID3D12Fence_Signal(fence, 4);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     value = ID3D12Fence_GetCompletedValue(fence);
-    ok(value == 0, "Got unexpected value %"PRIu64".\n", value);
+    ok(value == 4, "Got unexpected value %"PRIu64".\n", value);
 
     /* Basic tests with single event. */
     event1 = create_event();
@@ -3873,26 +3873,26 @@ static void test_cpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     /* Attach event to multiple values. */
-    hr = ID3D12Fence_Signal(fence, 0);
+    hr = ID3D12Fence_Signal(fence, 100);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 3, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 103, event1);
     ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 5, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 105, event1);
     ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 9, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 109, event1);
     ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 12, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 112, event1);
     ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 12, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 112, event1);
     ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     for (i = 1; i < 13; ++i)
     {
-        hr = ID3D12Fence_Signal(fence, i);
+        hr = ID3D12Fence_Signal(fence, 100 + i);
         ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
         if (i == 3 || i == 5 || i == 9 || i == 12)
         {
@@ -3904,10 +3904,10 @@ static void test_cpu_signal_fence(void)
     }
 
     /* Tests with 2 events. */
-    hr = ID3D12Fence_Signal(fence, 0);
+    hr = ID3D12Fence_Signal(fence, 200);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     value = ID3D12Fence_GetCompletedValue(fence);
-    ok(value == 0, "Got unexpected value %"PRIu64".\n", value);
+    ok(value == 200, "Got unexpected value %"PRIu64".\n", value);
 
     event2 = create_event();
     ok(event2, "Failed to create event.\n");
@@ -3916,26 +3916,26 @@ static void test_cpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 100, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 300, event1);
     ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, ~(uint64_t)0, event2);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 1000, event2);
     ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
 
-    hr = ID3D12Fence_Signal(fence, 50);
+    hr = ID3D12Fence_Signal(fence, 250);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_Signal(fence, 99);
+    hr = ID3D12Fence_Signal(fence, 299);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_Signal(fence, 100);
+    hr = ID3D12Fence_Signal(fence, 300);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
@@ -3944,28 +3944,28 @@ static void test_cpu_signal_fence(void)
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_Signal(fence, 101);
+    hr = ID3D12Fence_Signal(fence, 301);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_Signal(fence, 0);
+    hr = ID3D12Fence_Signal(fence, 400);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_Signal(fence, 100);
+    hr = ID3D12Fence_Signal(fence, 500);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_Signal(fence, ~(uint64_t)0);
+    hr = ID3D12Fence_Signal(fence, 1000);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
@@ -3974,13 +3974,13 @@ static void test_cpu_signal_fence(void)
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_Signal(fence, ~(uint64_t)0);
+    hr = ID3D12Fence_Signal(fence, 1001);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
-    hr = ID3D12Fence_Signal(fence, 0);
+    hr = ID3D12Fence_Signal(fence, 1002);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
@@ -3988,22 +3988,22 @@ static void test_cpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     /* Attach two events to the same value. */
-    hr = ID3D12Fence_Signal(fence, 0);
+    hr = ID3D12Fence_Signal(fence, 2000);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 1, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 2001, event1);
     ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 1, event2);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 2001, event2);
     ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
-    hr = ID3D12Fence_Signal(fence, 3);
+    hr = ID3D12Fence_Signal(fence, 2003);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
@@ -4015,22 +4015,22 @@ static void test_cpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     /* Test passing signaled event. */
-    hr = ID3D12Fence_Signal(fence, 20);
+    hr = ID3D12Fence_Signal(fence, 3000);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     value = ID3D12Fence_GetCompletedValue(fence);
-    ok(value == 20, "Got unexpected value %"PRIu64".\n", value);
+    ok(value == 3000, "Got unexpected value %"PRIu64".\n", value);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     signal_event(event1);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 30, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 4000, event1);
     ok(SUCCEEDED(hr), "Failed to set event on completion, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_Signal(fence, 30);
+    hr = ID3D12Fence_Signal(fence, 4000);
     ok(SUCCEEDED(hr), "Failed to signal fence, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
@@ -4077,10 +4077,10 @@ static void test_gpu_signal_fence(void)
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == 10, "Got unexpected value %"PRIu64".\n", value);
 
-    queue_signal(queue, fence, 0);
+    queue_signal(queue, fence, 20);
     wait_queue_idle(device, queue);
     value = ID3D12Fence_GetCompletedValue(fence);
-    ok(value == 0, "Got unexpected value %"PRIu64".\n", value);
+    ok(value == 20, "Got unexpected value %"PRIu64".\n", value);
 
     /* Basic tests with single event. */
     event1 = create_event();
@@ -4088,54 +4088,54 @@ static void test_gpu_signal_fence(void)
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 5, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 30, event1);
     ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
-    queue_signal(queue, fence, 5);
+    queue_signal(queue, fence, 30);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 6, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 39, event1);
     ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
-    queue_signal(queue, fence, 7);
+    queue_signal(queue, fence, 40);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    queue_signal(queue, fence, 10);
+    queue_signal(queue, fence, 50);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     /* Attach one event to multiple values. */
-    queue_signal(queue, fence, 0);
+    queue_signal(queue, fence, 100);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 3, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 103, event1);
     ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 5, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 105, event1);
     ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 9, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 109, event1);
     ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 12, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 112, event1);
     ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 12, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 112, event1);
     ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     for (i = 1; i < 13; ++i)
     {
-        queue_signal(queue, fence, i);
+        queue_signal(queue, fence, 100 + i);
         wait_queue_idle(device, queue);
         if (i == 3 || i == 5 || i == 9 || i == 12)
         {
@@ -4147,10 +4147,10 @@ static void test_gpu_signal_fence(void)
     }
 
     /* Tests with 2 events. */
-    queue_signal(queue, fence, 0);
+    queue_signal(queue, fence, 200);
     wait_queue_idle(device, queue);
     value = ID3D12Fence_GetCompletedValue(fence);
-    ok(value == 0, "Got unexpected value %"PRIu64".\n", value);
+    ok(value == 200, "Got unexpected value %"PRIu64".\n", value);
 
     event2 = create_event();
     ok(event2, "Failed to create event.\n");
@@ -4159,26 +4159,26 @@ static void test_gpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 100, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 300, event1);
     ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, ~(uint64_t)0, event2);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 1000, event2);
     ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
 
-    queue_signal(queue, fence, 50);
+    queue_signal(queue, fence, 250);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    queue_signal(queue, fence, 99);
+    queue_signal(queue, fence, 299);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    queue_signal(queue, fence, 100);
+    queue_signal(queue, fence, 300);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
@@ -4187,28 +4187,28 @@ static void test_gpu_signal_fence(void)
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    queue_signal(queue, fence, 101);
+    queue_signal(queue, fence, 301);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    queue_signal(queue, fence, 0);
+    queue_signal(queue, fence, 400);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    queue_signal(queue, fence, 100);
+    queue_signal(queue, fence, 500);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    queue_signal(queue, fence, ~(uint64_t)0);
+    queue_signal(queue, fence, 1000);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
@@ -4217,13 +4217,13 @@ static void test_gpu_signal_fence(void)
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    queue_signal(queue, fence, ~(uint64_t)0);
+    queue_signal(queue, fence, 2000);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
-    queue_signal(queue, fence, 0);
+    queue_signal(queue, fence, 3000);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
@@ -4231,22 +4231,22 @@ static void test_gpu_signal_fence(void)
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
     /* Attach two events to the same value. */
-    queue_signal(queue, fence, 0);
+    queue_signal(queue, fence, 4000);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
 
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 1, event1);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 4001, event1);
     ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
-    hr = ID3D12Fence_SetEventOnCompletion(fence, 1, event2);
+    hr = ID3D12Fence_SetEventOnCompletion(fence, 4001, event2);
     ok(hr == S_OK, "Failed to set event on completion, hr %#x.\n", hr);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
     ret = wait_event(event2, 0);
     ok(ret == WAIT_TIMEOUT, "Got unexpected return value %#x.\n", ret);
-    queue_signal(queue, fence, 3);
+    queue_signal(queue, fence, 4003);
     wait_queue_idle(device, queue);
     ret = wait_event(event1, 0);
     ok(ret == WAIT_OBJECT_0, "Got unexpected return value %#x.\n", ret);
@@ -4434,11 +4434,7 @@ static void test_fence_values(void)
     ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == next_value, "Got value %#"PRIx64", expected %#"PRIx64".\n", value, next_value);
-    next_value = 0;
-    hr = ID3D12Fence_Signal(fence, next_value);
-    ok(hr == S_OK, "Failed to signal fence, hr %#x.\n", hr);
-    value = ID3D12Fence_GetCompletedValue(fence);
-    ok(value == next_value, "Got value %#"PRIx64", expected %#"PRIx64".\n", value, next_value);
+
     ID3D12Fence_Release(fence);
 
     hr = ID3D12Device_CreateFence(device, 0, D3D12_FENCE_FLAG_NONE, &IID_ID3D12Fence, (void **)&fence);
@@ -4448,11 +4444,7 @@ static void test_fence_values(void)
     wait_queue_idle(device, queue);
     value = ID3D12Fence_GetCompletedValue(fence);
     ok(value == next_value, "Got value %#"PRIx64", expected %#"PRIx64".\n", value, next_value);
-    next_value = 0;
-    queue_signal(queue, fence, next_value);
-    wait_queue_idle(device, queue);
-    value = ID3D12Fence_GetCompletedValue(fence);
-    ok(value == next_value, "Got value %#"PRIx64", expected %#"PRIx64".\n", value, next_value);
+
     ID3D12Fence_Release(fence);
 
     ID3D12CommandQueue_Release(queue);


### PR DESCRIPTION
Tested on NV with test suite, Metro, Control and WoW.

Queue submit out of order might not work as expected yet since we are currently serializing many virtual queues on top of one queue, but this feature does not seem to be used by much content out there. It would not work at any rate with current vkd3d as it stands anyways.

For now I'm keeping the old implementation around in case we need a fallback for certain drivers, but the goal is to remove the fallback path eventually.

Also, fix the test suite to not rely on non-monotonically increasing values. https://docs.microsoft.com/en-us/windows/win32/direct3d12/user-mode-heap-synchronization#fences specifies it as monotonically increasing, so not sure why tests don't follow that.

Fixes #65.