### PR TITLE
vkd3d: Require Vulkan headers > 1.1.124

### DIFF
--- a/README
+++ b/README
@@ -9,7 +9,7 @@ similar, but not identical, to Direct3D 12.
 Building vkd3d
 ==============
 
-Vkd3d depends on SPIRV-Headers and Vulkan-Headers (>= 1.1.113).
+Vkd3d depends on SPIRV-Headers and Vulkan-Headers (>= 1.1.124).
 
 Vkd3d generates some of its headers from IDL files. If you are using the
 release tarballs, then these headers are pre-generated and are included. If

--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,7 @@ AS_IF([test "x$ac_cv_header_spirv_unified1_GLSL_std_450_h" != "xyes" \
        -a "x$ac_cv_header_vulkan_GLSL_std_450_h" != "xyes"],
       [AC_MSG_ERROR([GLSL.std.450.h not found.])])
 
-VKD3D_CHECK_VULKAN_HEADER_VERSION([113], [AC_MSG_ERROR([Vulkan headers are too old, 1.1.113 is required.])])
+VKD3D_CHECK_VULKAN_HEADER_VERSION([124], [AC_MSG_ERROR([Vulkan headers are too old, 1.1.124 is required.])])
 
 AC_CHECK_DECL([SpvCapabilityDemoteToHelperInvocationEXT],, [AC_MSG_ERROR([SPIR-V headers are too old.])], [
 #ifdef HAVE_SPIRV_UNIFIED1_SPIRV_H


### PR DESCRIPTION
Implementing VK_KHR_timeline_semaphore extension requires vulkan
headers > 1.1.124.

[https://github.com/KhronosGroup/Vulkan-Headers/commit/0dd7c8c65276c8c62016f8224f9d5916492c3a63#diff-4febd94c0666d59030d8b1dd20c72403](https://github.com/KhronosGroup/Vulkan-Headers/commit/0dd7c8c65276c8c62016f8224f9d5916492c3a63#diff-4febd94c0666d59030d8b1dd20c72403)
