### PR TITLE
vkd3d: Support multiple viewports.

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -4287,10 +4287,10 @@ static void STDMETHODCALLTYPE d3d12_command_list_RSSetViewports(d3d12_command_li
 
     TRACE("iface %p, viewport_count %u, viewports %p.\n", iface, viewport_count, viewports);
 
-    if (viewport_count > 1)
+    if (viewport_count > ARRAY_SIZE(dyn_state->viewports))
     {
-        FIXME_ONCE("Viewport count %u currently not supported.\n", viewport_count);
-        viewport_count = 1;
+        FIXME_ONCE("Viewport count %u > D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE.\n", viewport_count);
+        viewport_count = ARRAY_SIZE(dyn_state->viewports);
     }
 
     for (i = 0; i < viewport_count; ++i)
@@ -4317,6 +4317,7 @@ static void STDMETHODCALLTYPE d3d12_command_list_RSSetViewports(d3d12_command_li
     {
         dyn_state->viewport_count = viewport_count;
         dyn_state->dirty_flags |= VKD3D_DYNAMIC_STATE_SCISSOR;
+        d3d12_command_list_invalidate_current_pipeline(list);
     }
 
     dyn_state->dirty_flags |= VKD3D_DYNAMIC_STATE_VIEWPORT;

--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -2886,8 +2886,7 @@ static bool d3d12_command_list_update_graphics_pipeline(struct d3d12_command_lis
     }
 
     if (!(vk_pipeline = d3d12_pipeline_state_get_or_create_pipeline(list->state,
-            list->dynamic_state.primitive_topology, list->dynamic_state.vertex_strides,
-            list->dsv_format, &vk_render_pass)))
+            &list->dynamic_state, list->dsv_format, &vk_render_pass)))
         return false;
 
     /* The render pass cache ensures that we use the same Vulkan render pass

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1095,6 +1095,9 @@ struct vkd3d_dynamic_state
 
     float blend_constants[4];
     uint32_t stencil_reference;
+
+    uint32_t vertex_strides[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
+    D3D12_PRIMITIVE_TOPOLOGY primitive_topology;
 };
 
 /* ID3D12CommandList */
@@ -1111,9 +1114,6 @@ struct d3d12_command_list
     bool is_recording;
     bool is_valid;
     VkCommandBuffer vk_command_buffer;
-
-    uint32_t strides[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
-    D3D12_PRIMITIVE_TOPOLOGY primitive_topology;
 
     DXGI_FORMAT index_buffer_format;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -66,6 +66,7 @@ struct d3d12_device;
 struct d3d12_resource;
 
 struct vkd3d_bindless_set_info;
+struct vkd3d_dynamic_state;
 
 struct vkd3d_vk_global_procs
 {
@@ -956,8 +957,7 @@ struct d3d12_pipeline_state_desc
 HRESULT d3d12_pipeline_state_create(struct d3d12_device *device, VkPipelineBindPoint bind_point,
         const struct d3d12_pipeline_state_desc *desc, struct d3d12_pipeline_state **state) DECLSPEC_HIDDEN;
 VkPipeline d3d12_pipeline_state_get_or_create_pipeline(struct d3d12_pipeline_state *state,
-        D3D12_PRIMITIVE_TOPOLOGY topology, const uint32_t *strides, VkFormat dsv_format,
-        VkRenderPass *vk_render_pass) DECLSPEC_HIDDEN;
+        const struct vkd3d_dynamic_state *dyn_state, VkFormat dsv_format, VkRenderPass *vk_render_pass) DECLSPEC_HIDDEN;
 struct d3d12_pipeline_state *unsafe_impl_from_ID3D12PipelineState(ID3D12PipelineState *iface) DECLSPEC_HIDDEN;
 
 struct vkd3d_buffer


### PR DESCRIPTION
Title. Moves things around a bit so that we only have to pass the dynamic state struct to look up the pipeline.