### PR TITLE
vkd3d: Implement depth bounds test.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3928,10 +3928,10 @@ static void d3d12_device_caps_init_feature_options1(struct d3d12_device *device)
 
 static void d3d12_device_caps_init_feature_options2(struct d3d12_device *device)
 {
+    const VkPhysicalDeviceFeatures *features = &device->device_info.features2.features;
     D3D12_FEATURE_DATA_D3D12_OPTIONS2 *options2 = &device->d3d12_caps.options2;
 
-    /* Currently not supported */
-    options2->DepthBoundsTestSupported = FALSE;
+    options2->DepthBoundsTestSupported = features->depthBounds;
     /* Requires VK_EXT_sample_locations */
     options2->ProgrammableSamplePositionsTier = D3D12_PROGRAMMABLE_SAMPLE_POSITIONS_TIER_NOT_SUPPORTED;
 }

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -2093,6 +2093,7 @@ static void d3d12_graphics_pipeline_state_init_dynamic_state(struct d3d12_graphi
         { VKD3D_DYNAMIC_STATE_SCISSOR,            VK_DYNAMIC_STATE_SCISSOR            },
         { VKD3D_DYNAMIC_STATE_BLEND_CONSTANTS,    VK_DYNAMIC_STATE_BLEND_CONSTANTS    },
         { VKD3D_DYNAMIC_STATE_STENCIL_REFERENCE,  VK_DYNAMIC_STATE_STENCIL_REFERENCE  },
+        { VKD3D_DYNAMIC_STATE_DEPTH_BOUNDS,       VK_DYNAMIC_STATE_DEPTH_BOUNDS       },
     };
 
     /* Enable dynamic states as necessary */
@@ -2100,6 +2101,9 @@ static void d3d12_graphics_pipeline_state_init_dynamic_state(struct d3d12_graphi
 
     if (graphics->ds_desc.stencilTestEnable)
         graphics->dynamic_state_flags |= VKD3D_DYNAMIC_STATE_STENCIL_REFERENCE;
+
+    if (graphics->ds_desc.depthBoundsTestEnable)
+        graphics->dynamic_state_flags |= VKD3D_DYNAMIC_STATE_DEPTH_BOUNDS;
 
     for (i = 0; i < graphics->rt_count; i++)
     {
@@ -2255,9 +2259,9 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     }
 
     ds_desc_from_d3d12(&graphics->ds_desc, &desc->depth_stencil_state);
-    if (graphics->ds_desc.depthBoundsTestEnable)
+    if (graphics->ds_desc.depthBoundsTestEnable && !features->depthBounds)
     {
-        ERR("Depth bounds test not supported.\n");
+        ERR("Depth bounds test not supported by device.\n");
         hr = E_INVALIDARG;
         goto fail;
     }

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -828,7 +828,7 @@ struct d3d12_root_signature *unsafe_impl_from_ID3D12RootSignature(ID3D12RootSign
 int vkd3d_parse_root_signature_v_1_0(const struct vkd3d_shader_code *dxbc,
         struct vkd3d_versioned_root_signature_desc *desc) DECLSPEC_HIDDEN;
 
-#define VKD3D_MAX_DYNAMIC_STATE_COUNT (4)
+#define VKD3D_MAX_DYNAMIC_STATE_COUNT (5)
 
 enum vkd3d_dynamic_state_flag
 {
@@ -836,6 +836,7 @@ enum vkd3d_dynamic_state_flag
     VKD3D_DYNAMIC_STATE_SCISSOR           = (1 << 1),
     VKD3D_DYNAMIC_STATE_BLEND_CONSTANTS   = (1 << 2),
     VKD3D_DYNAMIC_STATE_STENCIL_REFERENCE = (1 << 3),
+    VKD3D_DYNAMIC_STATE_DEPTH_BOUNDS      = (1 << 4),
 };
 
 struct d3d12_graphics_pipeline_state
@@ -1095,6 +1096,9 @@ struct vkd3d_dynamic_state
 
     float blend_constants[4];
     uint32_t stencil_reference;
+
+    float min_depth_bounds;
+    float max_depth_bounds;
 
     uint32_t vertex_strides[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
     D3D12_PRIMITIVE_TOPOLOGY primitive_topology;


### PR DESCRIPTION
Used by RE Engine games for a small potential performance gain.