### PR TITLE
Various Monster Hunter World fixes

### DIFF
--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -4103,6 +4103,9 @@ static bool needs_private_io_variable(const struct vkd3d_shader_signature *signa
     bool have_sysval = false;
     unsigned int i, count;
 
+    if (builtin && builtin->spirv_array_size)
+        return true;
+
     if (*component_count == VKD3D_VEC4_SIZE)
         return false;
 

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -7934,11 +7934,8 @@ static void vkd3d_dxbc_compiler_emit_sample_c(struct vkd3d_dxbc_compiler *compil
     SpvImageOperandsMask operands_mask = 0;
     unsigned int image_operand_count = 0;
     struct vkd3d_shader_image image;
-    uint32_t image_operands[1];
+    uint32_t image_operands[2];
     SpvOp op;
-
-    if (vkd3d_shader_instruction_has_texel_offset(instruction))
-        FIXME("Texel offset not supported.\n");
 
     if (instruction->handler_idx == VKD3DSIH_SAMPLE_C_LZ)
     {
@@ -7954,6 +7951,14 @@ static void vkd3d_dxbc_compiler_emit_sample_c(struct vkd3d_dxbc_compiler *compil
 
     vkd3d_dxbc_compiler_prepare_image(compiler,
             &image, &src[1].reg, &src[2].reg, VKD3D_IMAGE_FLAG_SAMPLED | VKD3D_IMAGE_FLAG_DEPTH);
+
+    if (vkd3d_shader_instruction_has_texel_offset(instruction))
+    {
+        operands_mask |= SpvImageOperandsConstOffsetMask;
+        image_operands[image_operand_count++] = vkd3d_dxbc_compiler_emit_texel_offset(compiler,
+                instruction, image.resource_type_info);
+    }
+
     sampled_type_id = vkd3d_spirv_get_type_id(builder, image.sampled_type, 1);
     coordinate_id = vkd3d_dxbc_compiler_emit_load_src(compiler, &src[0], VKD3DSP_WRITEMASK_ALL);
     dref_id = vkd3d_dxbc_compiler_emit_load_src(compiler, &src[3], VKD3DSP_WRITEMASK_0);

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2951,10 +2951,24 @@ void d3d12_desc_create_srv(struct d3d12_desc *descriptor,
 
         switch (desc->ViewDimension)
         {
+            case D3D12_SRV_DIMENSION_TEXTURE1D:
+                vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_1D;
+                vkd3d_desc.miplevel_idx = desc->u.Texture1D.MostDetailedMip;
+                vkd3d_desc.miplevel_count = desc->u.Texture1D.MipLevels;
+                vkd3d_desc.layer_count = 1;
+                break;
+            case D3D12_SRV_DIMENSION_TEXTURE1DARRAY:
+                vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
+                vkd3d_desc.miplevel_idx = desc->u.Texture1DArray.MostDetailedMip;
+                vkd3d_desc.miplevel_count = desc->u.Texture1DArray.MipLevels;
+                vkd3d_desc.layer_idx = desc->u.Texture1DArray.FirstArraySlice;
+                vkd3d_desc.layer_count = desc->u.Texture1DArray.ArraySize;
+                break;
             case D3D12_SRV_DIMENSION_TEXTURE2D:
                 vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_2D;
                 vkd3d_desc.miplevel_idx = desc->u.Texture2D.MostDetailedMip;
                 vkd3d_desc.miplevel_count = desc->u.Texture2D.MipLevels;
+                vkd3d_desc.layer_count = 1;
                 if (desc->u.Texture2D.PlaneSlice)
                     FIXME("Ignoring plane slice %u.\n", desc->u.Texture2D.PlaneSlice);
                 if (desc->u.Texture2D.ResourceMinLODClamp)
@@ -2973,6 +2987,7 @@ void d3d12_desc_create_srv(struct d3d12_desc *descriptor,
                 break;
             case D3D12_SRV_DIMENSION_TEXTURE2DMS:
                 vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_2D;
+                vkd3d_desc.layer_count = 1;
                 break;
             case D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY:
                 vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
@@ -3182,8 +3197,21 @@ static void vkd3d_create_texture_uav(struct d3d12_desc *descriptor,
     {
         switch (desc->ViewDimension)
         {
+            case D3D12_UAV_DIMENSION_TEXTURE1D:
+                vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_1D;
+                vkd3d_desc.miplevel_idx = desc->u.Texture1D.MipSlice;
+                vkd3d_desc.layer_count = 1;
+                break;
+            case D3D12_UAV_DIMENSION_TEXTURE1DARRAY:
+                vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
+                vkd3d_desc.miplevel_idx = desc->u.Texture1DArray.MipSlice;
+                vkd3d_desc.layer_idx = desc->u.Texture1DArray.FirstArraySlice;
+                vkd3d_desc.layer_count = desc->u.Texture1DArray.ArraySize;
+                break;
             case D3D12_UAV_DIMENSION_TEXTURE2D:
+                vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_2D;
                 vkd3d_desc.miplevel_idx = desc->u.Texture2D.MipSlice;
+                vkd3d_desc.layer_count = 1;
                 if (desc->u.Texture2D.PlaneSlice)
                     FIXME("Ignoring plane slice %u.\n", desc->u.Texture2D.PlaneSlice);
                 break;
@@ -3435,7 +3463,19 @@ void d3d12_rtv_desc_create_rtv(struct d3d12_rtv_desc *rtv_desc, struct d3d12_dev
     {
         switch (desc->ViewDimension)
         {
+            case D3D12_RTV_DIMENSION_TEXTURE1D:
+                vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_1D;
+                vkd3d_desc.miplevel_idx = desc->u.Texture1D.MipSlice;
+                vkd3d_desc.layer_count = 1;
+                break;
+            case D3D12_RTV_DIMENSION_TEXTURE1DARRAY:
+                vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
+                vkd3d_desc.miplevel_idx = desc->u.Texture1DArray.MipSlice;
+                vkd3d_desc.layer_idx = desc->u.Texture1DArray.FirstArraySlice;
+                vkd3d_desc.layer_count = desc->u.Texture1DArray.ArraySize;
+                break;
             case D3D12_RTV_DIMENSION_TEXTURE2D:
+                vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_2D;
                 vkd3d_desc.miplevel_idx = desc->u.Texture2D.MipSlice;
                 vkd3d_desc.layer_count = 1;
                 if (desc->u.Texture2D.PlaneSlice)
@@ -3539,6 +3579,16 @@ void d3d12_dsv_desc_create_dsv(struct d3d12_dsv_desc *dsv_desc, struct d3d12_dev
 
         switch (desc->ViewDimension)
         {
+            case D3D12_DSV_DIMENSION_TEXTURE1D:
+                vkd3d_desc.miplevel_idx = desc->u.Texture1D.MipSlice;
+                vkd3d_desc.layer_count = 1;
+                break;
+            case D3D12_DSV_DIMENSION_TEXTURE1DARRAY:
+                vkd3d_desc.view_type = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
+                vkd3d_desc.miplevel_idx = desc->u.Texture1DArray.MipSlice;
+                vkd3d_desc.layer_idx = desc->u.Texture1DArray.FirstArraySlice;
+                vkd3d_desc.layer_count = desc->u.Texture1DArray.ArraySize;
+                break;
             case D3D12_DSV_DIMENSION_TEXTURE2D:
                 vkd3d_desc.miplevel_idx = desc->u.Texture2D.MipSlice;
                 vkd3d_desc.layer_count = 1;


### PR DESCRIPTION
Fixes more crashes that occur in the game, as well as a bunch of `fixme` messages and related rendering issues.