### PR TITLE
vkd3d: Remove legacy fence/semaphore path.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -1452,6 +1452,12 @@ static HRESULT vkd3d_init_device_caps(struct d3d12_device *device,
         }
     }
 
+    if (!vulkan_info->KHR_timeline_semaphore)
+    {
+        ERR("Timeline semaphores are not supported by this implementation. This is required for correct operation.\n");
+        return E_INVALIDARG;
+    }
+
     return S_OK;
 }
 


### PR DESCRIPTION
Prepares for a rewrite of queue submission, the legacy path is never
run in practice and will likely break in subtle ways.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>