### PR TITLE
Persistently map host-visible heaps

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -393,11 +393,8 @@ struct d3d12_heap
     bool is_private;
     D3D12_HEAP_DESC desc;
 
-    pthread_mutex_t mutex;
-
     VkDeviceMemory vk_memory;
     void *map_ptr;
-    unsigned int map_count;
     uint32_t vk_memory_type;
 
     struct d3d12_resource *buffer_resource;
@@ -435,8 +432,6 @@ struct d3d12_resource
         VkImage vk_image;
     } u;
     unsigned int flags;
-
-    unsigned int map_count;
 
     struct d3d12_heap *heap;
     uint64_t heap_offset;


### PR DESCRIPTION
Maps the heap once during creation and fills it with zeroes, which seems to fix some font texture corruption in Resident Evil 2, and may slightly reduce CPU overhead in some games that call Map/Unmap very frequently as those functions are now essentially no-ops (except flush/invalidate on some platforms).