### PR TITLE
Sampler rework

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -4614,7 +4614,6 @@ HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
     const bool use_sparse_resources = device->vk_info.sparse_properties.residencyNonResidentStrict;
     D3D12_HEAP_PROPERTIES heap_properties;
     D3D12_RESOURCE_DESC resource_desc;
-    VkResult vr;
     HRESULT hr;
 
     TRACE("Creating resources for NULL views.\n");
@@ -4713,15 +4712,6 @@ HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
             &null_resources->vk_2d_storage_image_view))
         goto fail;
 
-    /* Sampler */
-    if ((vr = d3d12_create_sampler(device, D3D12_FILTER_MIN_MAG_MIP_LINEAR,
-            D3D12_TEXTURE_ADDRESS_MODE_CLAMP, D3D12_TEXTURE_ADDRESS_MODE_CLAMP, D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
-            0.0f, 1, D3D12_COMPARISON_FUNC_ALWAYS, -FLT_MAX, FLT_MAX, &null_resources->vk_sampler)))
-    {
-        hr = hresult_from_vk_result(vr);
-        goto fail;
-    }
-
     /* set Vulkan object names */
     vkd3d_set_vk_object_name_utf8(device, (uint64_t)null_resources->vk_buffer,
             VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, "NULL buffer");
@@ -4743,8 +4733,6 @@ HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
             VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, "NULL 2D UAV image");
     vkd3d_set_vk_object_name_utf8(device, (uint64_t)null_resources->vk_2d_storage_image_view,
             VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, "NULL 2D UAV image view");
-    vkd3d_set_vk_object_name_utf8(device, (uint64_t)null_resources->vk_sampler,
-            VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT, "NULL sampler");
     if (!use_sparse_resources)
     {
         vkd3d_set_vk_object_name_utf8(device, (uint64_t)null_resources->vk_storage_buffer_memory,
@@ -4781,8 +4769,6 @@ void vkd3d_destroy_null_resources(struct vkd3d_null_resources *null_resources,
     VK_CALL(vkDestroyImageView(device->vk_device, null_resources->vk_2d_storage_image_view, NULL));
     VK_CALL(vkDestroyImage(device->vk_device, null_resources->vk_2d_storage_image, NULL));
     VK_CALL(vkFreeMemory(device->vk_device, null_resources->vk_2d_storage_image_memory, NULL));
-
-    VK_CALL(vkDestroySampler(device->vk_device, null_resources->vk_sampler, NULL));
 
     memset(null_resources, 0, sizeof(*null_resources));
 }

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3388,6 +3388,65 @@ static VkSamplerAddressMode vk_address_mode_from_d3d12(D3D12_TEXTURE_ADDRESS_MOD
     }
 }
 
+static bool d3d12_sampler_needs_border_color(D3D12_TEXTURE_ADDRESS_MODE u,
+        D3D12_TEXTURE_ADDRESS_MODE v, D3D12_TEXTURE_ADDRESS_MODE w)
+{
+    return u == D3D12_TEXTURE_ADDRESS_MODE_BORDER ||
+        v == D3D12_TEXTURE_ADDRESS_MODE_BORDER ||
+        w == D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+}
+
+static VkBorderColor vk_static_border_color_from_d3d12(D3D12_STATIC_BORDER_COLOR border_color)
+{
+    switch (border_color)
+    {
+        case D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK:
+            return VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+        case D3D12_STATIC_BORDER_COLOR_OPAQUE_BLACK:
+            return VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+        case D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE:
+            return VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+        default:
+            WARN("Unhandled static border color %u.\n", border_color);
+            return VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+    }
+}
+
+HRESULT d3d12_create_static_sampler(struct d3d12_device *device,
+        const D3D12_STATIC_SAMPLER_DESC *desc, VkSampler *vk_sampler)
+{
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
+    struct VkSamplerCreateInfo sampler_desc;
+    VkResult vr;
+
+    sampler_desc.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    sampler_desc.pNext = NULL;
+    sampler_desc.flags = 0;
+    sampler_desc.magFilter = vk_filter_from_d3d12(D3D12_DECODE_MAG_FILTER(desc->Filter));
+    sampler_desc.minFilter = vk_filter_from_d3d12(D3D12_DECODE_MIN_FILTER(desc->Filter));
+    sampler_desc.mipmapMode = vk_mipmap_mode_from_d3d12(D3D12_DECODE_MIP_FILTER(desc->Filter));
+    sampler_desc.addressModeU = vk_address_mode_from_d3d12(desc->AddressU);
+    sampler_desc.addressModeV = vk_address_mode_from_d3d12(desc->AddressV);
+    sampler_desc.addressModeW = vk_address_mode_from_d3d12(desc->AddressW);
+    sampler_desc.mipLodBias = desc->MipLODBias;
+    sampler_desc.anisotropyEnable = D3D12_DECODE_IS_ANISOTROPIC_FILTER(desc->Filter);
+    sampler_desc.maxAnisotropy = desc->MaxAnisotropy;
+    sampler_desc.compareEnable = D3D12_DECODE_IS_COMPARISON_FILTER(desc->Filter);
+    sampler_desc.compareOp = sampler_desc.compareEnable ? vk_compare_op_from_d3d12(desc->ComparisonFunc) : 0;
+    sampler_desc.minLod = desc->MinLOD;
+    sampler_desc.maxLod = desc->MaxLOD;
+    sampler_desc.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+    sampler_desc.unnormalizedCoordinates = VK_FALSE;
+
+    if (d3d12_sampler_needs_border_color(desc->AddressU, desc->AddressV, desc->AddressW))
+        sampler_desc.borderColor = vk_static_border_color_from_d3d12(desc->BorderColor);
+
+    if ((vr = VK_CALL(vkCreateSampler(device->vk_device, &sampler_desc, NULL, vk_sampler))) < 0)
+        WARN("Failed to create Vulkan sampler, vr %d.\n", vr);
+
+    return hresult_from_vk_result(vr);
+}
+
 static VkResult d3d12_create_sampler(struct d3d12_device *device, D3D12_FILTER filter,
         D3D12_TEXTURE_ADDRESS_MODE address_u, D3D12_TEXTURE_ADDRESS_MODE address_v,
         D3D12_TEXTURE_ADDRESS_MODE address_w, float mip_lod_bias, unsigned int max_anisotropy,
@@ -3459,22 +3518,6 @@ void d3d12_desc_create_sampler(struct d3d12_desc *sampler,
     sampler->magic = VKD3D_DESCRIPTOR_MAGIC_SAMPLER;
     sampler->vk_descriptor_type = VK_DESCRIPTOR_TYPE_SAMPLER;
     sampler->u.view = view;
-}
-
-HRESULT vkd3d_create_static_sampler(struct d3d12_device *device,
-        const D3D12_STATIC_SAMPLER_DESC *desc, VkSampler *vk_sampler)
-{
-    VkResult vr;
-
-    if (desc->AddressU == D3D12_TEXTURE_ADDRESS_MODE_BORDER
-            || desc->AddressV == D3D12_TEXTURE_ADDRESS_MODE_BORDER
-            || desc->AddressW == D3D12_TEXTURE_ADDRESS_MODE_BORDER)
-        FIXME("Ignoring border %#x.\n", desc->BorderColor);
-
-    vr = d3d12_create_sampler(device, desc->Filter, desc->AddressU,
-            desc->AddressV, desc->AddressW, desc->MipLODBias, desc->MaxAnisotropy,
-            desc->ComparisonFunc, desc->MinLOD, desc->MaxLOD, vk_sampler);
-    return hresult_from_vk_result(vr);
 }
 
 /* RTVs */

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -3412,6 +3412,32 @@ static VkBorderColor vk_static_border_color_from_d3d12(D3D12_STATIC_BORDER_COLOR
     }
 }
 
+static VkBorderColor vk_border_color_from_d3d12(const float *border_color)
+{
+    unsigned int i;
+
+    static const struct
+    {
+        float color[4];
+        VkBorderColor vk_border_color;
+    }
+    border_colors[] = {
+      { {0.0f, 0.0f, 0.0f, 0.0f}, VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK },
+      { {0.0f, 0.0f, 0.0f, 1.0f}, VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK },
+      { {1.0f, 1.0f, 1.0f, 1.0f}, VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE },
+    };
+
+    for (i = 0; i < ARRAY_SIZE(border_colors); i++)
+    {
+        if (!memcmp(border_color, border_colors[i].color, sizeof(border_colors[i].color)))
+            return border_colors[i].vk_border_color;
+    }
+
+    FIXME("Unsupported border color (%f, %f, %f, %f).\n",
+            border_color[0], border_color[1], border_color[2], border_color[3]);
+    return VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+}
+
 HRESULT d3d12_create_static_sampler(struct d3d12_device *device,
         const D3D12_STATIC_SAMPLER_DESC *desc, VkSampler *vk_sampler)
 {
@@ -3447,44 +3473,39 @@ HRESULT d3d12_create_static_sampler(struct d3d12_device *device,
     return hresult_from_vk_result(vr);
 }
 
-static VkResult d3d12_create_sampler(struct d3d12_device *device, D3D12_FILTER filter,
-        D3D12_TEXTURE_ADDRESS_MODE address_u, D3D12_TEXTURE_ADDRESS_MODE address_v,
-        D3D12_TEXTURE_ADDRESS_MODE address_w, float mip_lod_bias, unsigned int max_anisotropy,
-        D3D12_COMPARISON_FUNC comparison_func, float min_lod, float max_lod,
-        VkSampler *vk_sampler)
+static HRESULT d3d12_create_sampler(struct d3d12_device *device,
+        const D3D12_SAMPLER_DESC *desc, VkSampler *vk_sampler)
 {
-    const struct vkd3d_vk_device_procs *vk_procs;
+    const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     struct VkSamplerCreateInfo sampler_desc;
     VkResult vr;
-
-    vk_procs = &device->vk_procs;
-
-    if (D3D12_DECODE_FILTER_REDUCTION(filter) == D3D12_FILTER_REDUCTION_TYPE_MINIMUM
-            || D3D12_DECODE_FILTER_REDUCTION(filter) == D3D12_FILTER_REDUCTION_TYPE_MAXIMUM)
-        FIXME("Min/max reduction mode not supported.\n");
 
     sampler_desc.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
     sampler_desc.pNext = NULL;
     sampler_desc.flags = 0;
-    sampler_desc.magFilter = vk_filter_from_d3d12(D3D12_DECODE_MAG_FILTER(filter));
-    sampler_desc.minFilter = vk_filter_from_d3d12(D3D12_DECODE_MIN_FILTER(filter));
-    sampler_desc.mipmapMode = vk_mipmap_mode_from_d3d12(D3D12_DECODE_MIP_FILTER(filter));
-    sampler_desc.addressModeU = vk_address_mode_from_d3d12(address_u);
-    sampler_desc.addressModeV = vk_address_mode_from_d3d12(address_v);
-    sampler_desc.addressModeW = vk_address_mode_from_d3d12(address_w);
-    sampler_desc.mipLodBias = mip_lod_bias;
-    sampler_desc.anisotropyEnable = D3D12_DECODE_IS_ANISOTROPIC_FILTER(filter);
-    sampler_desc.maxAnisotropy = max_anisotropy;
-    sampler_desc.compareEnable = D3D12_DECODE_IS_COMPARISON_FILTER(filter);
-    sampler_desc.compareOp = sampler_desc.compareEnable ? vk_compare_op_from_d3d12(comparison_func) : 0;
-    sampler_desc.minLod = min_lod;
-    sampler_desc.maxLod = max_lod;
+    sampler_desc.magFilter = vk_filter_from_d3d12(D3D12_DECODE_MAG_FILTER(desc->Filter));
+    sampler_desc.minFilter = vk_filter_from_d3d12(D3D12_DECODE_MIN_FILTER(desc->Filter));
+    sampler_desc.mipmapMode = vk_mipmap_mode_from_d3d12(D3D12_DECODE_MIP_FILTER(desc->Filter));
+    sampler_desc.addressModeU = vk_address_mode_from_d3d12(desc->AddressU);
+    sampler_desc.addressModeV = vk_address_mode_from_d3d12(desc->AddressV);
+    sampler_desc.addressModeW = vk_address_mode_from_d3d12(desc->AddressW);
+    sampler_desc.mipLodBias = desc->MipLODBias;
+    sampler_desc.anisotropyEnable = D3D12_DECODE_IS_ANISOTROPIC_FILTER(desc->Filter);
+    sampler_desc.maxAnisotropy = desc->MaxAnisotropy;
+    sampler_desc.compareEnable = D3D12_DECODE_IS_COMPARISON_FILTER(desc->Filter);
+    sampler_desc.compareOp = sampler_desc.compareEnable ? vk_compare_op_from_d3d12(desc->ComparisonFunc) : 0;
+    sampler_desc.minLod = desc->MinLOD;
+    sampler_desc.maxLod = desc->MaxLOD;
     sampler_desc.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
     sampler_desc.unnormalizedCoordinates = VK_FALSE;
+
+    if (d3d12_sampler_needs_border_color(desc->AddressU, desc->AddressV, desc->AddressW))
+        sampler_desc.borderColor = vk_border_color_from_d3d12(desc->BorderColor);
+
     if ((vr = VK_CALL(vkCreateSampler(device->vk_device, &sampler_desc, NULL, vk_sampler))) < 0)
         WARN("Failed to create Vulkan sampler, vr %d.\n", vr);
 
-    return vr;
+    return hresult_from_vk_result(vr);
 }
 
 void d3d12_desc_create_sampler(struct d3d12_desc *sampler,
@@ -3498,18 +3519,10 @@ void d3d12_desc_create_sampler(struct d3d12_desc *sampler,
         return;
     }
 
-    if (desc->AddressU == D3D12_TEXTURE_ADDRESS_MODE_BORDER
-            || desc->AddressV == D3D12_TEXTURE_ADDRESS_MODE_BORDER
-            || desc->AddressW == D3D12_TEXTURE_ADDRESS_MODE_BORDER)
-        FIXME("Ignoring border color {%.8e, %.8e, %.8e, %.8e}.\n",
-                desc->BorderColor[0], desc->BorderColor[1], desc->BorderColor[2], desc->BorderColor[3]);
-
     if (!(view = vkd3d_view_create(VKD3D_VIEW_TYPE_SAMPLER)))
         return;
 
-    if (d3d12_create_sampler(device, desc->Filter, desc->AddressU,
-            desc->AddressV, desc->AddressW, desc->MipLODBias, desc->MaxAnisotropy,
-            desc->ComparisonFunc, desc->MinLOD, desc->MaxLOD, &view->u.vk_sampler) < 0)
+    if (FAILED(d3d12_create_sampler(device, desc, &view->u.vk_sampler)))
     {
         vkd3d_free(view);
         return;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -874,7 +874,7 @@ static HRESULT d3d12_root_signature_init_static_samplers(struct d3d12_root_signa
     {
         const D3D12_STATIC_SAMPLER_DESC *s = &desc->pStaticSamplers[i];
 
-        if (FAILED(hr = vkd3d_create_static_sampler(root_signature->device, s, &root_signature->static_samplers[i])))
+        if (FAILED(hr = d3d12_create_static_sampler(root_signature->device, s, &root_signature->static_samplers[i])))
             goto cleanup;
 
         vk_binding = &vk_binding_info[i];

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1297,8 +1297,6 @@ struct vkd3d_null_resources
     VkImage vk_2d_storage_image;
     VkImageView vk_2d_storage_image_view;
     VkDeviceMemory vk_2d_storage_image_memory;
-
-    VkSampler vk_sampler;
 };
 
 HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -581,7 +581,7 @@ void d3d12_desc_write_atomic(struct d3d12_desc *dst, const struct d3d12_desc *sr
 
 bool vkd3d_create_raw_buffer_view(struct d3d12_device *device,
         D3D12_GPU_VIRTUAL_ADDRESS gpu_address, VkBufferView *vk_buffer_view) DECLSPEC_HIDDEN;
-HRESULT vkd3d_create_static_sampler(struct d3d12_device *device,
+HRESULT d3d12_create_static_sampler(struct d3d12_device *device,
         const D3D12_STATIC_SAMPLER_DESC *desc, VkSampler *vk_sampler) DECLSPEC_HIDDEN;
 
 struct d3d12_rtv_desc


### PR DESCRIPTION
Allows us to support border colors for both static and descriptor-based samplers, which fixes a whole bunch of warnings in various games (e.g. MHW, Control). The following caveats apply:
- D3D12 static border colors do not distinguish between float/uint border colors.
- Arbitrary border colors are not (yet) supported in the Vulkan API.