### PR TITLE
vkd3d: Fix 32-bit compiler warnings

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5719,14 +5719,14 @@ static void STDMETHODCALLTYPE d3d12_command_list_EndRenderPass(d3d12_command_lis
 static void STDMETHODCALLTYPE d3d12_command_list_InitializeMetaCommand(d3d12_command_list_iface *iface,
         ID3D12MetaCommand *meta_command, const void *parameter_data, SIZE_T parameter_size)
 {
-    FIXME("iface %p, meta_command %p, parameter_data %p, parameter_size %zu stub!\n",
+    FIXME("iface %p, meta_command %p, parameter_data %p, parameter_size %lu stub!\n",
             iface, meta_command, parameter_data, parameter_size);
 }
 
 static void STDMETHODCALLTYPE d3d12_command_list_ExecuteMetaCommand(d3d12_command_list_iface *iface,
         ID3D12MetaCommand *meta_command, const void *parameter_data, SIZE_T parameter_size)
 {
-    FIXME("iface %p, meta_command %p, parameter_data %p, parameter_size %zu stub!\n",
+    FIXME("iface %p, meta_command %p, parameter_data %p, parameter_size %lu stub!\n",
             iface, meta_command, parameter_data, parameter_size);
 }
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -3837,7 +3837,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_EnqueueMakeResident(d3d12_device_i
         D3D12_RESIDENCY_FLAGS flags, UINT num_objects, ID3D12Pageable *const *objects,
         ID3D12Fence *fence_to_signal, UINT64 fence_value_to_signal)
 {
-    FIXME_ONCE("iface %p, flags %#x, num_objects %u, objects %p, fence_to_signal %p, fence_value_to_signal %lu stub!\n",
+    FIXME_ONCE("iface %p, flags %#x, num_objects %u, objects %p, fence_to_signal %p, fence_value_to_signal %"PRIu64" stub!\n",
             iface, flags, num_objects, objects, fence_to_signal, fence_value_to_signal);
 
     return ID3D12Fence_Signal(fence_to_signal, fence_value_to_signal);
@@ -4054,7 +4054,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_device_CreateMetaCommand(d3d12_device_ifa
         REFGUID command_id, UINT node_mask, const void *param_data, SIZE_T param_size,
         REFIID iid, void **meta_command)
 {
-    FIXME("iface %p, command_id %s, node_mask %#x, param_data %p, param_size %zu, iid %s, meta_command %p stub!\n",
+    FIXME("iface %p, command_id %s, node_mask %#x, param_data %p, param_size %lu, iid %s, meta_command %p stub!\n",
             iface, debugstr_guid(command_id), node_mask, param_data, param_size, debugstr_guid(iid), meta_command);
 
     return E_NOTIMPL;


### PR DESCRIPTION
This fixes a couple of 32-bit compiler warnings, atleast for GCC-9.3.

eg.
```
libs/vkd3d/command.c:5722:11: warning: format ‘%zu’ expects argument of type ‘size_t’, but argument 7 has type ‘SIZE_T’ {aka ‘long unsigned int’} [-Wformat=]
 5722 |     FIXME("iface %p, meta_command %p, parameter_data %p, parameter_size %zu stub!\n",
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 5723 |             iface, meta_command, parameter_data, parameter_size);
      |                                                  ~~~~~~~~~~~~~~
      |                                                  |
      |                                                  SIZE_T {aka long unsigned int}
```


Signed-off-by: Sveinar Søpler <cybermax@dexter.no>