### PR TITLE
Support CastingFullyTypedFormatSupported.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4289,8 +4289,7 @@ static void d3d12_device_caps_init_feature_options3(struct d3d12_device *device)
     D3D12_FEATURE_DATA_D3D12_OPTIONS3 *options3 = &device->d3d12_caps.options3;
 
     options3->CopyQueueTimestampQueriesSupported = !!device->copy_queue->timestamp_bits;
-    /* Requires changes to format compatibility */
-    options3->CastingFullyTypedFormatSupported = FALSE;
+    options3->CastingFullyTypedFormatSupported = TRUE;
     /* Currently not supported */
     options3->WriteBufferImmediateSupportFlags = 0;
     /* Currently not supported */

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -829,11 +829,15 @@ static unsigned int max_miplevel_count(const D3D12_RESOURCE_DESC *desc)
 static const struct vkd3d_format_compatibility_list *vkd3d_get_format_compatibility_list(
         const struct d3d12_device *device, DXGI_FORMAT dxgi_format)
 {
+    DXGI_FORMAT typeless_format;
     unsigned int i;
+
+    if (!(typeless_format = vkd3d_get_typeless_format(device, dxgi_format)))
+        typeless_format = dxgi_format;
 
     for (i = 0; i < device->format_compatibility_list_count; ++i)
     {
-        if (device->format_compatibility_lists[i].typeless_format == dxgi_format)
+        if (device->format_compatibility_lists[i].typeless_format == typeless_format)
             return &device->format_compatibility_lists[i];
     }
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1595,6 +1595,7 @@ void vkd3d_format_copy_data(const struct vkd3d_format *format, const uint8_t *sr
 
 const struct vkd3d_format *vkd3d_get_format(const struct d3d12_device *device,
         DXGI_FORMAT dxgi_format, bool depth_stencil) DECLSPEC_HIDDEN;
+DXGI_FORMAT vkd3d_get_typeless_format(const struct d3d12_device *device, DXGI_FORMAT dxgi_format) DECLSPEC_HIDDEN;
 const struct vkd3d_format *vkd3d_find_uint_format(const struct d3d12_device *device,
         DXGI_FORMAT dxgi_format) DECLSPEC_HIDDEN;
 


### PR DESCRIPTION
This shouldn't have any impact on performance on any recent-ish hardware since we stay within a format family. 

I'm exploiting this for shader-based depth<->color copies since we may need to be able to create an `R32_FLOAT` view for pretty much any `R32_*` image.