### PR TITLE
vkd3d: Enforce that WCHAR is actually a WCHAR.

### DIFF
--- a/include/vkd3d_windows.h
+++ b/include/vkd3d_windows.h
@@ -33,10 +33,6 @@
 
 #if !defined(_WIN32) || defined(__WIDL__)
 
-# if !defined(__WIDL__) && !defined(VKD3D_WIN32_WCHAR)
-#  include <wchar.h>
-# endif
-
 # ifdef __GNUC__
 #  define DECLSPEC_ALIGN(x) __attribute__((aligned(x)))
 # endif
@@ -91,11 +87,7 @@ typedef unsigned long ULONG_PTR;
 
 typedef ULONG_PTR SIZE_T;
 
-# ifdef VKD3D_WIN32_WCHAR
 typedef unsigned short WCHAR;
-# else
-typedef wchar_t WCHAR;
-# endif /* VKD3D_WIN32_WCHAR */
 typedef void *HANDLE;
 
 typedef const WCHAR* LPCWSTR;


### PR DESCRIPTION
We will need to receive 2-byte WCHARs from apps.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>