### PR TITLE
Barrier rework

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -1751,7 +1751,7 @@ static void d3d12_command_list_emit_render_pass_transition(struct d3d12_command_
 
     dsv = &list->dsv;
 
-    if (dsv->view)
+    if (dsv->view && list->dsv_layout)
     {
         stage_mask |= vk_render_pass_barrier_from_view(dsv->view,
                 dsv->resource, mode, &vk_image_barriers[j++]);

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2282,9 +2282,7 @@ static void d3d12_desc_update_bindless_descriptor(struct d3d12_desc *dst)
     {
         descriptor_info.image.sampler = dst->u.view->u.vk_sampler;
         descriptor_info.image.imageView = dst->u.view->u.vk_image_view;
-        descriptor_info.image.imageLayout = dst->magic == VKD3D_DESCRIPTOR_MAGIC_SRV
-                ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
-                : VK_IMAGE_LAYOUT_GENERAL;
+        descriptor_info.image.imageLayout = dst->u.view->info.texture.vk_layout;
     }
 
     vk_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2157,6 +2157,12 @@ HRESULT vkd3d_create_image_resource(ID3D12Device *device,
     object->flags = VKD3D_RESOURCE_EXTERNAL;
     object->flags |= create_info->flags & VKD3D_RESOURCE_PUBLIC_FLAGS;
     object->initial_state = D3D12_RESOURCE_STATE_COMMON;
+    object->common_layout = vk_common_image_layout_from_d3d12_desc(&object->desc);
+
+    /* DXGI only allows transfer and render target usage */
+    if (object->flags & VKD3D_RESOURCE_PRESENT_STATE_TRANSITION)
+        object->common_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
     if (create_info->flags & VKD3D_RESOURCE_PRESENT_STATE_TRANSITION)
         object->present_state = create_info->present_state;
     else

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -265,8 +265,8 @@ struct vkd3d_render_pass_key
     unsigned int attachment_count;
     bool depth_enable;
     bool stencil_enable;
-    bool depth_stencil_write;
-    bool padding;
+    bool depth_write;
+    bool stencil_write;
     unsigned int sample_count;
     VkFormat vk_formats[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT + 1];
 };
@@ -851,6 +851,7 @@ struct d3d12_graphics_pipeline_state
     unsigned int null_attachment_mask;
     VkFormat dsv_format;
     VkFormat rtv_formats[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
+    VkImageLayout dsv_layout;
     VkRenderPass render_pass;
 
     D3D12_INDEX_BUFFER_STRIP_CUT_VALUE index_buffer_strip_cut_value;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1131,8 +1131,8 @@ struct d3d12_command_list
 
     DXGI_FORMAT index_buffer_format;
 
-    VkImageView rtvs[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
-    VkImageView dsv;
+    struct d3d12_rtv_desc rtvs[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
+    struct d3d12_dsv_desc dsv;
     unsigned int fb_width;
     unsigned int fb_height;
     unsigned int fb_layer_count;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -455,6 +455,11 @@ static inline bool d3d12_resource_is_texture(const struct d3d12_resource *resour
     return resource->desc.Dimension != D3D12_RESOURCE_DIMENSION_BUFFER;
 }
 
+static inline VkImageLayout d3d12_resource_pick_layout(const struct d3d12_resource *resource, VkImageLayout layout)
+{
+    return resource->flags & VKD3D_RESOURCE_LINEAR_TILING ? VK_IMAGE_LAYOUT_GENERAL : layout;
+}
+
 bool d3d12_resource_is_cpu_accessible(const struct d3d12_resource *resource) DECLSPEC_HIDDEN;
 HRESULT d3d12_resource_validate_desc(const D3D12_RESOURCE_DESC *desc, struct d3d12_device *device) DECLSPEC_HIDDEN;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1136,7 +1136,6 @@ struct d3d12_command_list
     unsigned int fb_width;
     unsigned int fb_height;
     unsigned int fb_layer_count;
-    VkFormat dsv_format;
 
     bool xfb_enabled;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -514,6 +514,7 @@ struct vkd3d_view
         struct
         {
             VkImageViewType vk_view_type;
+            VkImageLayout vk_layout;
             unsigned int miplevel_idx;
             unsigned int layer_idx;
             unsigned int layer_count;
@@ -527,6 +528,7 @@ void vkd3d_view_incref(struct vkd3d_view *view) DECLSPEC_HIDDEN;
 struct vkd3d_texture_view_desc
 {
     VkImageViewType view_type;
+    VkImageLayout layout;
     const struct vkd3d_format *format;
     unsigned int miplevel_idx;
     unsigned int miplevel_count;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -436,6 +436,7 @@ struct d3d12_resource
     struct d3d12_heap *heap;
     uint64_t heap_offset;
 
+    VkImageLayout common_layout;
     D3D12_RESOURCE_STATES initial_state;
     D3D12_RESOURCE_STATES present_state;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1134,6 +1134,7 @@ struct d3d12_command_list
 
     struct d3d12_rtv_desc rtvs[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
     struct d3d12_dsv_desc dsv;
+    VkImageLayout dsv_layout;
     unsigned int fb_width;
     unsigned int fb_height;
     unsigned int fb_layer_count;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1685,6 +1685,22 @@ static inline VkImageSubresourceRange vk_subresource_range_from_layers(const VkI
     return range;
 }
 
+static inline VkImageSubresourceLayers vk_subresource_layers_from_view(const struct vkd3d_view *view)
+{
+    VkImageSubresourceLayers layers;
+    layers.aspectMask = view->format->vk_aspect_mask;
+    layers.mipLevel = view->info.texture.miplevel_idx;
+    layers.baseArrayLayer = view->info.texture.layer_idx;
+    layers.layerCount = view->info.texture.layer_count;
+    return layers;
+}
+
+static inline VkImageSubresourceRange vk_subresource_range_from_view(const struct vkd3d_view *view)
+{
+    VkImageSubresourceLayers layers = vk_subresource_layers_from_view(view);
+    return vk_subresource_range_from_layers(&layers);
+}
+
 static inline bool d3d12_box_is_empty(const D3D12_BOX *box)
 {
     return box->right <= box->left || box->bottom <= box->top || box->back <= box->front;


### PR DESCRIPTION
Fixes most validation errors related to image layouts, as well as some real-world issues like The Talos Priciple showing corruption with MSAA enabled.

Here's how it works:
- Based on the usage flags, a common layout is determined for each image resource.
- The common layout is always used for descriptors.
- For transfer operations, the images involved will be transitioned to the `TRANSFER_{SRC,DST}_OPTIMAL` layout before the transfer op itself, and back to their common layout afterwards.
- Color attachments are transitioned to `COLOR_ATTACHMENT_OPTIMAL` when beginning a render pass, and back to their common layout afterwards.
- Depth-stencil attachments are transitioned to the pipeline-specific DSV layout when beginning a render pass, and back to their common layout afterwards.
- `ResourceBarrier` does not perform any layout transitions, and instead batches everything into one single `VkMemoryBarrier`. The `COMMON` state is conservative and acts as a full barrier.

Caveats and things that still need to be done down the line:
- We should add a fast path for "suspending" the active render pass, so that beginning and ending queries does not introduce unnecessary stalls.
- ~~We cannot know the exact layout of the depth-stencil attachment at draw time when creating an SRV descriptor for it, so this is often going to be wrong.~~ Actually not an issue according to spec chapter 11.4.1.
- Initial state transitions should be performed by the command list that first uses a resource on the GPU timeline, rather than the CPU timeline. Not entirely sure how to tackle this.
- Destroying render targets that are bound to a command list is going to cause undefined behaviour.
- We should use an `UNDEFINED -> whatever` transition when overriding the entire destination image in transfer operations.

Unrelated:
- RTV/DSV clears need a rewrite.
- Render passes need some work; currently we're using `DONT_CARE` incorrectly for depth/stencil aspects.