### PR TITLE
Suspend renderpasses

### DIFF
--- a/libs/vkd3d/command.c
+++ b/libs/vkd3d/command.c
@@ -5082,28 +5082,18 @@ static void STDMETHODCALLTYPE d3d12_command_list_ClearDepthStencilView(d3d12_com
     attachment_desc.flags = 0;
     attachment_desc.format = dsv_desc->format->vk_format;
     attachment_desc.samples = dsv_desc->sample_count;
-    if (flags & D3D12_CLEAR_FLAG_DEPTH)
-    {
-        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-    }
-    else
-    {
-        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    }
-    if (flags & D3D12_CLEAR_FLAG_STENCIL)
-    {
-        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
-    }
-    else
-    {
-        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    }
+    attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
     attachment_desc.initialLayout = dsv_desc->resource->common_layout;
     attachment_desc.finalLayout = dsv_desc->resource->common_layout;
+
+    if (flags & D3D12_CLEAR_FLAG_DEPTH)
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+
+    if (flags & D3D12_CLEAR_FLAG_STENCIL)
+        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 
     ds_reference.attachment = 0;
     ds_reference.layout = dsv_desc->view->info.texture.vk_layout;

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -1189,27 +1189,10 @@ static HRESULT vkd3d_render_pass_cache_create_pass_locked(struct vkd3d_render_pa
         attachments[attachment_index].flags = 0;
         attachments[attachment_index].format = key->vk_formats[index];
         attachments[attachment_index].samples = key->sample_count;
-
-        if (key->depth_enable)
-        {
-            attachments[attachment_index].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
-            attachments[attachment_index].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-        }
-        else
-        {
-            attachments[attachment_index].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-            attachments[attachment_index].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        }
-        if (key->stencil_enable)
-        {
-            attachments[attachment_index].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
-            attachments[attachment_index].stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
-        }
-        else
-        {
-            attachments[attachment_index].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-            attachments[attachment_index].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        }
+        attachments[attachment_index].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+        attachments[attachment_index].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachments[attachment_index].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+        attachments[attachment_index].stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
         attachments[attachment_index].initialLayout = depth_layout;
         attachments[attachment_index].finalLayout = depth_layout;
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1142,6 +1142,7 @@ struct d3d12_command_list
     bool xfb_enabled;
 
     bool is_predicated;
+    bool render_pass_suspended;
 
     VkFramebuffer current_framebuffer;
     VkPipeline current_pipeline;


### PR DESCRIPTION
Optimizes useless barriers away and fixes performance regressions introduced with the barrier rework (only SotTR seems to be really affected).