### PR TITLE
Implement sampler border colors

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -153,6 +153,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(KHR_TIMELINE_SEMAPHORE, KHR_timeline_semaphore),
     /* EXT extensions */
     VK_EXTENSION(EXT_CONDITIONAL_RENDERING, EXT_conditional_rendering),
+    VK_EXTENSION(EXT_CUSTOM_BORDER_COLOR, EXT_custom_border_color),
     VK_EXTENSION(EXT_DEBUG_MARKER, EXT_debug_marker),
     VK_EXTENSION(EXT_DEPTH_CLIP_ENABLE, EXT_depth_clip_enable),
     VK_EXTENSION(EXT_DESCRIPTOR_INDEXING, EXT_descriptor_indexing),
@@ -708,6 +709,7 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     VkPhysicalDeviceSubgroupSizeControlPropertiesEXT *subgroup_size_control_properties;
     VkPhysicalDeviceInlineUniformBlockPropertiesEXT *inline_uniform_block_properties;
     VkPhysicalDeviceBufferDeviceAddressFeaturesKHR *buffer_device_address_features;
+    VkPhysicalDeviceCustomBorderColorPropertiesEXT *custom_border_color_properties;
     VkPhysicalDeviceConditionalRenderingFeaturesEXT *conditional_rendering_features;
     VkPhysicalDeviceDescriptorIndexingPropertiesEXT *descriptor_indexing_properties;
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT *vertex_divisor_properties;
@@ -719,6 +721,7 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT *vertex_divisor_features;
     VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *buffer_alignment_features;
     VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT *demote_features;
+    VkPhysicalDeviceCustomBorderColorFeaturesEXT *custom_border_color_features;
     VkPhysicalDeviceTimelineSemaphoreFeaturesKHR *timeline_semaphore_features;
     VkPhysicalDevicePushDescriptorPropertiesKHR *push_descriptor_properties;
     VkPhysicalDeviceShaderCoreProperties2AMD *shader_core_properties2;
@@ -751,6 +754,8 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     subgroup_properties = &info->subgroup_properties;
     timeline_semaphore_features = &info->timeline_semaphore_features;
     timeline_semaphore_properties = &info->timeline_semaphore_properties;
+    custom_border_color_properties = &info->custom_border_color_properties;
+    custom_border_color_features = &info->custom_border_color_features;
     subgroup_size_control_properties = &info->subgroup_size_control_properties;
     shader_core_properties = &info->shader_core_properties;
     shader_core_properties2 = &info->shader_core_properties2;
@@ -792,6 +797,14 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     {
         conditional_rendering_features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT;
         vk_prepend_struct(&info->features2, conditional_rendering_features);
+    }
+
+    if (vulkan_info->EXT_custom_border_color)
+    {
+        custom_border_color_features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT;
+        vk_prepend_struct(&info->features2, custom_border_color_features);
+        custom_border_color_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT;
+        vk_prepend_struct(&info->properties2, custom_border_color_properties);
     }
 
     if (vulkan_info->EXT_depth_clip_enable)
@@ -1159,6 +1172,7 @@ static void vkd3d_trace_physical_device_features(const struct vkd3d_physical_dev
     const VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT *demote_features;
     const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *buffer_alignment_features;
     const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT *divisor_features;
+    const VkPhysicalDeviceCustomBorderColorFeaturesEXT *border_color_features;
     const VkPhysicalDeviceDescriptorIndexingFeaturesEXT *descriptor_indexing;
     const VkPhysicalDeviceDepthClipEnableFeaturesEXT *depth_clip_features;
     const VkPhysicalDeviceFeatures *features = &info->features2.features;
@@ -1295,6 +1309,11 @@ static void vkd3d_trace_physical_device_features(const struct vkd3d_physical_dev
             divisor_features->vertexAttributeInstanceRateDivisor);
     TRACE("    vertexAttributeInstanceRateZeroDivisor: %#x.\n",
             divisor_features->vertexAttributeInstanceRateZeroDivisor);
+
+    border_color_features = &info->custom_border_color_features;
+    TRACE("  VkPhysicalDeviceCustomBorderColorFeaturesEXT:\n");
+    TRACE("    customBorderColors: %#x\n", border_color_features->customBorderColors);
+    TRACE("    customBorderColorWithoutFormat: %#x\n", border_color_features->customBorderColorWithoutFormat);
 }
 
 static HRESULT vkd3d_init_device_extensions(struct d3d12_device *device,

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -61,6 +61,8 @@
 #define VKD3D_MAX_DESCRIPTOR_SETS 8u
 #define VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS 6u
 
+#define VKD3D_PIPELINE_BIND_POINT_COUNT 2u
+
 struct d3d12_command_list;
 struct d3d12_device;
 struct d3d12_resource;
@@ -1163,8 +1165,8 @@ struct d3d12_command_list
     VkRenderPass current_render_pass;
     VkBuffer uav_counter_address_buffer;
     struct vkd3d_dynamic_state dynamic_state;
-    struct vkd3d_pipeline_bindings pipeline_bindings[VK_PIPELINE_BIND_POINT_RANGE_SIZE];
-    struct vkd3d_descriptor_updates packed_descriptors[VK_PIPELINE_BIND_POINT_RANGE_SIZE];
+    struct vkd3d_pipeline_bindings pipeline_bindings[VKD3D_PIPELINE_BIND_POINT_COUNT];
+    struct vkd3d_descriptor_updates packed_descriptors[VKD3D_PIPELINE_BIND_POINT_COUNT];
 
     VkDescriptorSet descriptor_heaps[VKD3D_MAX_BINDLESS_DESCRIPTOR_SETS];
 

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -117,6 +117,7 @@ struct vkd3d_vulkan_info
     bool KHR_timeline_semaphore;
     /* EXT device extensions */
     bool EXT_conditional_rendering;
+    bool EXT_custom_border_color;
     bool EXT_debug_marker;
     bool EXT_depth_clip_enable;
     bool EXT_descriptor_indexing;
@@ -1507,6 +1508,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceSubgroupProperties subgroup_properties;
     VkPhysicalDeviceTimelineSemaphorePropertiesKHR timeline_semaphore_properties;
     VkPhysicalDeviceSubgroupSizeControlPropertiesEXT subgroup_size_control_properties;
+    VkPhysicalDeviceCustomBorderColorPropertiesEXT custom_border_color_properties;
     VkPhysicalDeviceShaderCorePropertiesAMD shader_core_properties;
     VkPhysicalDeviceShaderCoreProperties2AMD shader_core_properties2;
     VkPhysicalDeviceShaderSMBuiltinsPropertiesNV shader_sm_builtins_properties;
@@ -1523,6 +1525,7 @@ struct vkd3d_physical_device_info
     VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT texel_buffer_alignment_features;
     VkPhysicalDeviceTransformFeedbackFeaturesEXT xfb_features;
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT vertex_divisor_features;
+    VkPhysicalDeviceCustomBorderColorFeaturesEXT custom_border_color_features;
     VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timeline_semaphore_features;
 
     VkPhysicalDeviceFeatures2 features2;

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -42124,6 +42124,207 @@ static void test_update_tile_mappings(void)
     destroy_test_context(&context);
 }
 
+static void test_sampler_border_color(void)
+{
+    ID3D12DescriptorHeap *heap, *sampler_heap, *heaps[2];
+    D3D12_STATIC_SAMPLER_DESC static_sampler_desc;
+    D3D12_ROOT_SIGNATURE_DESC root_signature_desc;
+    D3D12_DESCRIPTOR_RANGE descriptor_range[2];
+    D3D12_ROOT_PARAMETER root_parameters[2];
+    ID3D12GraphicsCommandList *command_list;
+    D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle;
+    D3D12_GPU_DESCRIPTOR_HANDLE gpu_handle;
+    ID3D12RootSignature *root_signature;
+    ID3D12PipelineState *pipeline_state;
+    D3D12_SAMPLER_DESC sampler_desc;
+    struct test_context_desc desc;
+    struct resource_readback rb;
+    struct test_context context;
+    ID3D12CommandQueue *queue;
+    ID3D12Resource *texture;
+    ID3D12Device *device;
+    unsigned int i;
+    HRESULT hr;
+
+    static const DWORD ps_code[] =
+    {
+#if 0
+        Texture2D t;
+        SamplerState s;
+
+        float4 main(float4 position : SV_POSITION) : SV_Target
+        {
+            return t.Sample(s, float2(-0.5f, 1.5f));
+        }
+#endif
+        0x43425844, 0xf3ecc2e5, 0x82cfcce7, 0x1adcaaac, 0x9a0d8de0, 0x00000001, 0x0000010c, 0x00000003,
+        0x0000002c, 0x00000060, 0x00000094, 0x4e475349, 0x0000002c, 0x00000001, 0x00000008, 0x00000020,
+        0x00000000, 0x00000001, 0x00000003, 0x00000000, 0x0000000f, 0x505f5653, 0x5449534f, 0x004e4f49,
+        0x4e47534f, 0x0000002c, 0x00000001, 0x00000008, 0x00000020, 0x00000000, 0x00000000, 0x00000003,
+        0x00000000, 0x0000000f, 0x545f5653, 0x65677261, 0xabab0074, 0x58454853, 0x00000070, 0x00000050,
+        0x0000001c, 0x0100086a, 0x0300005a, 0x00106000, 0x00000000, 0x04001858, 0x00107000, 0x00000000,
+        0x00005555, 0x03000065, 0x001020f2, 0x00000000, 0x8e000045, 0x800000c2, 0x00155543, 0x001020f2,
+        0x00000000, 0x00004002, 0xbf000000, 0x3fc00000, 0x00000000, 0x00000000, 0x00107e46, 0x00000000,
+        0x00106000, 0x00000000, 0x0100003e,
+    };
+    static const D3D12_SHADER_BYTECODE ps = {ps_code, sizeof(ps_code)};
+    static const float red[] = {1.0f, 0.0f, 0.0f, 1.0f};
+    static const struct
+    {
+        bool static_sampler;
+        unsigned int expected_color;
+        float border_color[4];
+        D3D12_STATIC_BORDER_COLOR static_border_color;
+    }
+    tests[] =
+    {
+        {false, 0x00000000u, {0.0f, 0.0f, 0.0f, 0.0f}},
+        {false, 0xff000000u, {0.0f, 0.0f, 0.0f, 1.0f}},
+        {false, 0xffffffffu, {1.0f, 1.0f, 1.0f, 1.0f}},
+        {false, 0xccb3804du, {0.3f, 0.5f, 0.7f, 0.8f}},
+        {true,  0x00000000u, {0.0f, 0.0f, 0.0f, 0.0f}, D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK},
+        {true,  0xff000000u, {0.0f, 0.0f, 0.0f, 1.0f}, D3D12_STATIC_BORDER_COLOR_OPAQUE_BLACK},
+        {true,  0xffffffffu, {1.0f, 1.0f, 1.0f, 1.0f}, D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE},
+    };
+
+    memset(&desc, 0, sizeof(desc));
+    desc.rt_width = 640;
+    desc.rt_height = 480;
+    desc.no_root_signature = true;
+    if (!init_test_context(&context, &desc))
+        return;
+    device = context.device;
+    command_list = context.list;
+    queue = context.queue;
+
+    descriptor_range[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    descriptor_range[0].NumDescriptors = 1;
+    descriptor_range[0].BaseShaderRegister = 0;
+    descriptor_range[0].RegisterSpace = 0;
+    descriptor_range[0].OffsetInDescriptorsFromTableStart = 0;
+    root_parameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+    root_parameters[0].DescriptorTable.NumDescriptorRanges = 1;
+    root_parameters[0].DescriptorTable.pDescriptorRanges = &descriptor_range[0];
+    root_parameters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+    descriptor_range[1].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER;
+    descriptor_range[1].NumDescriptors = 1;
+    descriptor_range[1].BaseShaderRegister = 0;
+    descriptor_range[1].RegisterSpace = 0;
+    descriptor_range[1].OffsetInDescriptorsFromTableStart = 0;
+    root_parameters[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+    root_parameters[1].DescriptorTable.NumDescriptorRanges = 1;
+    root_parameters[1].DescriptorTable.pDescriptorRanges = &descriptor_range[1];
+    root_parameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+    heap = create_gpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 1);
+    cpu_handle = ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart(heap);
+    gpu_handle = ID3D12DescriptorHeap_GetGPUDescriptorHandleForHeapStart(heap);
+
+    sampler_heap = create_gpu_descriptor_heap(device, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, 1);
+
+    {
+        D3D12_SUBRESOURCE_DATA sub;
+        sub.pData = red;
+        sub.RowPitch = 4;
+        sub.SlicePitch = 4;
+        texture = create_default_texture2d(device, 1, 1, 1, 1, DXGI_FORMAT_R8G8B8A8_UNORM,
+                D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_COPY_DEST);
+        upload_texture_data(texture, &sub, 1, queue, command_list);
+        reset_command_list(command_list, context.allocator);
+        transition_resource_state(command_list, texture,
+                D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+
+        ID3D12Device_CreateShaderResourceView(device, texture, NULL, cpu_handle);
+    }
+
+    for (i = 0; i < ARRAY_SIZE(tests); ++i)
+    {
+        vkd3d_test_set_context("Test %u", i);
+
+        memset(&root_signature_desc, 0, sizeof(root_signature_desc));
+        root_signature_desc.NumParameters = ARRAY_SIZE(root_parameters);
+        root_signature_desc.pParameters = root_parameters;
+
+        if (tests[i].static_sampler)
+        {
+            root_signature_desc.NumParameters -= 1;
+            root_signature_desc.NumStaticSamplers = 1;
+            root_signature_desc.pStaticSamplers = &static_sampler_desc;
+
+            memset(&static_sampler_desc, 0, sizeof(static_sampler_desc));
+            static_sampler_desc.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+            static_sampler_desc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+            static_sampler_desc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+            static_sampler_desc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+            static_sampler_desc.BorderColor = tests[i].static_border_color;
+            static_sampler_desc.ShaderRegister = 0;
+            static_sampler_desc.RegisterSpace = 0;
+            static_sampler_desc.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+        }
+        else
+        {
+            memset(&sampler_desc, 0, sizeof(sampler_desc));
+            sampler_desc.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+            sampler_desc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+            sampler_desc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+            sampler_desc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+            memcpy(sampler_desc.BorderColor, tests[i].border_color, sizeof(sampler_desc.BorderColor));
+            ID3D12Device_CreateSampler(device, &sampler_desc, get_cpu_sampler_handle(&context, sampler_heap, 0));
+        }
+
+        hr = create_root_signature(device, &root_signature_desc, &root_signature);
+        ok(hr == S_OK, "Failed to create root signature, hr %#x.\n", hr);
+
+        pipeline_state = create_pipeline_state(device, root_signature,
+                context.render_target_desc.Format, NULL, &ps, NULL);
+
+        ID3D12GraphicsCommandList_ClearRenderTargetView(command_list, context.rtv, red, 0, NULL);
+
+        ID3D12GraphicsCommandList_OMSetRenderTargets(command_list, 1, &context.rtv, false, NULL);
+        ID3D12GraphicsCommandList_SetGraphicsRootSignature(command_list, root_signature);
+        ID3D12GraphicsCommandList_SetPipelineState(command_list, pipeline_state);
+        heaps[0] = heap;
+        heaps[1] = sampler_heap;
+        ID3D12GraphicsCommandList_SetDescriptorHeaps(command_list, ARRAY_SIZE(heaps), heaps);
+        ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(command_list, 0, gpu_handle);
+        if (!tests[i].static_sampler)
+        {
+            ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(command_list, 1,
+                    get_gpu_sampler_handle(&context, sampler_heap, 0));
+        }
+        ID3D12GraphicsCommandList_IASetPrimitiveTopology(command_list, D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+        ID3D12GraphicsCommandList_RSSetViewports(command_list, 1, &context.viewport);
+        ID3D12GraphicsCommandList_RSSetScissorRects(command_list, 1, &context.scissor_rect);
+        ID3D12GraphicsCommandList_DrawInstanced(command_list, 3, 1, 0, 0);
+
+        transition_resource_state(command_list, context.render_target,
+                D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_COPY_SOURCE);
+
+        get_texture_readback_with_command_list(context.render_target, 0, &rb, queue, command_list);
+
+        unsigned int color = get_readback_uint(&rb, 0, 0, 0);
+        ok(compare_color(color, tests[i].expected_color, 1),
+                "Got color 0x%08x, expected 0x%08x.\n",
+                color, tests[i].expected_color);
+
+        release_resource_readback(&rb);
+
+        ID3D12RootSignature_Release(root_signature);
+        ID3D12PipelineState_Release(pipeline_state);
+
+        reset_command_list(command_list, context.allocator);
+        transition_resource_state(command_list, context.render_target,
+                D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_RENDER_TARGET);
+    }
+    vkd3d_test_set_context(NULL);
+
+    ID3D12Resource_Release(texture);
+    ID3D12DescriptorHeap_Release(heap);
+    ID3D12DescriptorHeap_Release(sampler_heap);
+    destroy_test_context(&context);
+}
+
 START_TEST(d3d12)
 {
     pfn_D3D12CreateDevice = get_d3d12_pfn(D3D12CreateDevice);
@@ -42335,4 +42536,5 @@ START_TEST(d3d12)
     run_test(test_raytracing);
     run_test(test_get_resource_tiling);
     run_test(test_update_tile_mappings);
+    run_test(test_sampler_border_color);
 }


### PR DESCRIPTION
Uses the new `VK_EXT_custom_border_color` extension added in the Vulkan 1.2.140 update. The test is going to fail on systems not supporting the extension for obvious reasons.