### PR TITLE
Implement CopyTiles

### DIFF
--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2275,13 +2275,13 @@ static HRESULT d3d12_resource_init_sparse_info(struct d3d12_resource *resource,
 
     for (i = 0; i < sparse->tile_count; i++)
     {
-        if (resource->desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
+        if (d3d12_resource_is_buffer(resource))
         {
             VkDeviceSize offset = VKD3D_TILE_SIZE * i;
             sparse->tiles[i].u.buffer.offset = offset;
             sparse->tiles[i].u.buffer.length = min(VKD3D_TILE_SIZE, resource->desc.Width - offset);
         }
-        else if (i >= sparse->packed_mips.StartTileIndexInOverallResource)
+        else if (sparse->packed_mips.NumPackedMips && i >= sparse->packed_mips.StartTileIndexInOverallResource)
         {
             VkDeviceSize offset = VKD3D_TILE_SIZE * (i - sparse->packed_mips.StartTileIndexInOverallResource);
             sparse->tiles[i].u.buffer.offset = vk_memory_requirements.imageMipTailOffset + offset;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1787,6 +1787,16 @@ static inline VkImageSubresourceRange vk_subresource_range_from_layers(const VkI
     return range;
 }
 
+static inline VkImageSubresourceLayers vk_subresource_layers_from_subresource(const VkImageSubresource *subresource)
+{
+    VkImageSubresourceLayers layers;
+    layers.aspectMask = subresource->aspectMask;
+    layers.mipLevel = subresource->mipLevel;
+    layers.baseArrayLayer = subresource->arrayLayer;
+    layers.layerCount = 1;
+    return layers;
+}
+
 static inline VkImageSubresourceLayers vk_subresource_layers_from_view(const struct vkd3d_view *view)
 {
     VkImageSubresourceLayers layers;

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -357,8 +357,7 @@ static void get_buffer_readback_with_command_list(ID3D12Resource *buffer, DXGI_F
     resource_desc.Flags = D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE;
 
     hr = ID3D12Resource_GetHeapProperties(buffer, &heap_properties, NULL);
-    ok(SUCCEEDED(hr), "Failed to get heap properties.\n");
-    if (heap_properties.Type == D3D12_HEAP_TYPE_READBACK)
+    if (SUCCEEDED(hr) && heap_properties.Type == D3D12_HEAP_TYPE_READBACK)
     {
         rb_buffer = buffer;
         ID3D12Resource_AddRef(rb_buffer);


### PR DESCRIPTION
Title. Also fixes a bug when calling `UpdateTileMappings` for an image that has no mip tail.