### PR TITLE
vkd3d: Require Vulkan 1.1.

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -540,9 +540,17 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
     if (vk_global_procs->vkEnumerateInstanceVersion)
         vk_global_procs->vkEnumerateInstanceVersion(&loader_version);
 
+    if (loader_version < VKD3D_MIN_API_VERSION)
+    {
+        ERR("Vulkan %u.%u not supported by loader.\n",
+                VK_VERSION_MAJOR(VKD3D_MIN_API_VERSION),
+                VK_VERSION_MINOR(VKD3D_MIN_API_VERSION));
+        return E_INVALIDARG;
+    }
+
     /* Do not opt-in to versions we don't need yet. */
-    if (loader_version > VK_API_VERSION_1_1)
-        loader_version = VK_API_VERSION_1_1;
+    if (loader_version > VKD3D_MAX_API_VERSION)
+        loader_version = VKD3D_MAX_API_VERSION;
 
     application_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
     application_info.pNext = NULL;
@@ -617,11 +625,9 @@ static HRESULT vkd3d_instance_init(struct vkd3d_instance *instance,
     instance->vk_instance = vk_instance;
     instance->instance_version = loader_version;
 
-    TRACE("Created Vulkan instance %p.\n", vk_instance);
-    if (loader_version == VK_API_VERSION_1_1)
-        TRACE("Created Vulkan 1.1 instance.\n");
-    else
-        TRACE("Created Vulkan 1.0 instance.\n");
+    TRACE("Created Vulkan instance %p, version %u.%u.\n", vk_instance,
+            VK_VERSION_MAJOR(loader_version),
+            VK_VERSION_MINOR(loader_version));
 
     instance->refcount = 1;
 

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -142,7 +142,6 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
     VK_EXTENSION(KHR_DRAW_INDIRECT_COUNT, KHR_draw_indirect_count),
     VK_EXTENSION(KHR_GET_MEMORY_REQUIREMENTS_2, KHR_get_memory_requirements2),
     VK_EXTENSION(KHR_IMAGE_FORMAT_LIST, KHR_image_format_list),
-    VK_EXTENSION(KHR_MAINTENANCE3, KHR_maintenance3),
     VK_EXTENSION(KHR_PUSH_DESCRIPTOR, KHR_push_descriptor),
     VK_EXTENSION(KHR_TIMELINE_SEMAPHORE, KHR_timeline_semaphore),
     VK_EXTENSION(KHR_SHADER_FLOAT16_INT8, KHR_shader_float16_int8),
@@ -776,6 +775,9 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     subgroup_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES;
     vk_prepend_struct(&info->properties2, subgroup_properties);
 
+    maintenance3_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES;
+    vk_prepend_struct(&info->properties2, maintenance3_properties);
+
     if (vulkan_info->KHR_buffer_device_address)
     {
         buffer_device_address_features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR;
@@ -794,12 +796,6 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
     {
         push_descriptor_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR;
         vk_prepend_struct(&info->properties2, push_descriptor_properties);
-    }
-
-    if (vulkan_info->KHR_maintenance3)
-    {
-        maintenance3_properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES;
-        vk_prepend_struct(&info->properties2, maintenance3_properties);
     }
 
     if (vulkan_info->KHR_shader_float16_int8)

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -134,12 +134,6 @@ static const struct vkd3d_optional_extension_info optional_instance_extensions[]
     VK_DEBUG_EXTENSION(EXT_DEBUG_REPORT, EXT_debug_report),
 };
 
-static const char * const required_device_extensions[] =
-{
-    VK_KHR_MAINTENANCE1_EXTENSION_NAME,
-    VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME,
-};
-
 static const struct vkd3d_optional_extension_info optional_device_extensions[] =
 {
     /* KHR extensions */
@@ -1397,8 +1391,7 @@ static HRESULT vkd3d_init_device_extensions(struct d3d12_device *device,
         *user_extension_supported = NULL;
     }
 
-    *device_extension_count = vkd3d_check_extensions(vk_extensions, count,
-            required_device_extensions, ARRAY_SIZE(required_device_extensions),
+    *device_extension_count = vkd3d_check_extensions(vk_extensions, count, NULL, 0,
             optional_device_extensions, ARRAY_SIZE(optional_device_extensions),
             create_info->device_extensions, create_info->device_extension_count,
             optional_extensions ? optional_extensions->extensions : NULL,
@@ -1822,8 +1815,7 @@ static HRESULT vkd3d_create_vk_device(struct d3d12_device *device,
     device_info.pQueueCreateInfos = device_queue_info.vk_queue_create_info;
     device_info.enabledLayerCount = 0;
     device_info.ppEnabledLayerNames = NULL;
-    device_info.enabledExtensionCount = vkd3d_enable_extensions(extensions,
-            required_device_extensions, ARRAY_SIZE(required_device_extensions),
+    device_info.enabledExtensionCount = vkd3d_enable_extensions(extensions, NULL, 0,
             optional_device_extensions, ARRAY_SIZE(optional_device_extensions),
             create_info->device_extensions, create_info->device_extension_count,
             optional_extensions ? optional_extensions->extensions : NULL,

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -138,9 +138,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
 {
     /* KHR extensions */
     VK_EXTENSION(KHR_BUFFER_DEVICE_ADDRESS, KHR_buffer_device_address),
-    VK_EXTENSION(KHR_DEDICATED_ALLOCATION, KHR_dedicated_allocation),
     VK_EXTENSION(KHR_DRAW_INDIRECT_COUNT, KHR_draw_indirect_count),
-    VK_EXTENSION(KHR_GET_MEMORY_REQUIREMENTS_2, KHR_get_memory_requirements2),
     VK_EXTENSION(KHR_IMAGE_FORMAT_LIST, KHR_image_format_list),
     VK_EXTENSION(KHR_PUSH_DESCRIPTOR, KHR_push_descriptor),
     VK_EXTENSION(KHR_TIMELINE_SEMAPHORE, KHR_timeline_semaphore),

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -64,6 +64,9 @@
 
 #define VKD3D_TILE_SIZE 65536
 
+#define VKD3D_MIN_API_VERSION VK_API_VERSION_1_1
+#define VKD3D_MAX_API_VERSION VK_API_VERSION_1_1
+
 struct d3d12_command_list;
 struct d3d12_device;
 struct d3d12_resource;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -112,9 +112,7 @@ struct vkd3d_vulkan_info
 
     /* KHR device extensions */
     bool KHR_buffer_device_address;
-    bool KHR_dedicated_allocation;
     bool KHR_draw_indirect_count;
-    bool KHR_get_memory_requirements2;
     bool KHR_image_format_list;
     bool KHR_push_descriptor;
     bool KHR_timeline_semaphore;

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -116,7 +116,6 @@ struct vkd3d_vulkan_info
     bool KHR_draw_indirect_count;
     bool KHR_get_memory_requirements2;
     bool KHR_image_format_list;
-    bool KHR_maintenance3;
     bool KHR_push_descriptor;
     bool KHR_timeline_semaphore;
     bool KHR_shader_float16_int8;

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -151,13 +151,16 @@ VK_DEVICE_PFN(vkFreeCommandBuffers)
 VK_DEVICE_PFN(vkFreeDescriptorSets)
 VK_DEVICE_PFN(vkFreeMemory)
 VK_DEVICE_PFN(vkGetBufferMemoryRequirements)
+VK_DEVICE_PFN(vkGetBufferMemoryRequirements2)
 VK_DEVICE_PFN(vkGetDescriptorSetLayoutSupport)
 VK_DEVICE_PFN(vkGetDeviceMemoryCommitment)
 VK_DEVICE_PFN(vkGetDeviceQueue)
 VK_DEVICE_PFN(vkGetEventStatus)
 VK_DEVICE_PFN(vkGetFenceStatus)
 VK_DEVICE_PFN(vkGetImageMemoryRequirements)
+VK_DEVICE_PFN(vkGetImageMemoryRequirements2)
 VK_DEVICE_PFN(vkGetImageSparseMemoryRequirements)
+VK_DEVICE_PFN(vkGetImageSparseMemoryRequirements2)
 VK_DEVICE_PFN(vkGetImageSubresourceLayout)
 VK_DEVICE_PFN(vkGetPipelineCacheData)
 VK_DEVICE_PFN(vkGetQueryPoolResults)
@@ -191,11 +194,6 @@ VK_DEVICE_EXT_PFN(vkSignalSemaphoreKHR)
 /* VK_KHR_draw_indirect_count */
 VK_DEVICE_EXT_PFN(vkCmdDrawIndirectCountKHR)
 VK_DEVICE_EXT_PFN(vkCmdDrawIndexedIndirectCountKHR)
-
-/* VK_KHR_get_memory_requirements2 */
-VK_DEVICE_EXT_PFN(vkGetBufferMemoryRequirements2KHR)
-VK_DEVICE_EXT_PFN(vkGetImageMemoryRequirements2KHR)
-VK_DEVICE_EXT_PFN(vkGetImageSparseMemoryRequirements2KHR)
 
 /* VK_KHR_push_descriptor */
 VK_DEVICE_EXT_PFN(vkCmdPushDescriptorSetKHR)

--- a/libs/vkd3d/vulkan_procs.h
+++ b/libs/vkd3d/vulkan_procs.h
@@ -151,6 +151,7 @@ VK_DEVICE_PFN(vkFreeCommandBuffers)
 VK_DEVICE_PFN(vkFreeDescriptorSets)
 VK_DEVICE_PFN(vkFreeMemory)
 VK_DEVICE_PFN(vkGetBufferMemoryRequirements)
+VK_DEVICE_PFN(vkGetDescriptorSetLayoutSupport)
 VK_DEVICE_PFN(vkGetDeviceMemoryCommitment)
 VK_DEVICE_PFN(vkGetDeviceQueue)
 VK_DEVICE_PFN(vkGetEventStatus)
@@ -195,9 +196,6 @@ VK_DEVICE_EXT_PFN(vkCmdDrawIndexedIndirectCountKHR)
 VK_DEVICE_EXT_PFN(vkGetBufferMemoryRequirements2KHR)
 VK_DEVICE_EXT_PFN(vkGetImageMemoryRequirements2KHR)
 VK_DEVICE_EXT_PFN(vkGetImageSparseMemoryRequirements2KHR)
-
-/* VK_KHR_maintenance3 */
-VK_DEVICE_EXT_PFN(vkGetDescriptorSetLayoutSupportKHR)
 
 /* VK_KHR_push_descriptor */
 VK_DEVICE_EXT_PFN(vkCmdPushDescriptorSetKHR)


### PR DESCRIPTION
Allows us to skip a few annoying extension check in the memory allocation code.

We should aim for 1.2 later down the line in order to significantly reduce the extension spam, but considering the required driver support it's too early to do that.