### PR TITLE
configure.ac: Report that 1.2.140 is required, not 1.1.140.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,7 @@ AS_IF([test "x$ac_cv_header_spirv_unified1_GLSL_std_450_h" != "xyes" \
        -a "x$ac_cv_header_vulkan_GLSL_std_450_h" != "xyes"],
       [AC_MSG_ERROR([GLSL.std.450.h not found.])])
 
-VKD3D_CHECK_VULKAN_HEADER_VERSION([140], [AC_MSG_ERROR([Vulkan headers are too old, 1.1.140 is required.])])
+VKD3D_CHECK_VULKAN_HEADER_VERSION([140], [AC_MSG_ERROR([Vulkan headers are too old, 1.2.140 is required.])])
 
 AC_CHECK_DECL([SpvCapabilityDemoteToHelperInvocationEXT],, [AC_MSG_ERROR([SPIR-V headers are too old.])], [
 #ifdef HAVE_SPIRV_UNIFIED1_SPIRV_H


### PR DESCRIPTION
Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>