### PR TITLE
Memory allocation rework

### DIFF
--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -4622,6 +4622,9 @@ static HRESULT d3d12_device_init(struct d3d12_device *device,
     if (FAILED(hr = vkd3d_init_format_info(device)))
         goto out_stop_fence_worker;
 
+    if (FAILED(hr = vkd3d_memory_info_init(&device->memory_info, device)))
+        goto out_cleanup_format_info;
+
     if (FAILED(hr = vkd3d_init_null_resources(&device->null_resources, device)))
         goto out_cleanup_format_info;
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -111,34 +111,6 @@ static HRESULT vkd3d_select_memory_flags(struct d3d12_device *device, const D3D1
     return S_OK;
 }
 
-static HRESULT vkd3d_select_memory_type(struct d3d12_device *device, uint32_t memory_type_mask,
-        const D3D12_HEAP_PROPERTIES *heap_properties, D3D12_HEAP_FLAGS heap_flags, unsigned int *type_index)
-{
-    const VkPhysicalDeviceMemoryProperties *memory_info = &device->memory_properties;
-    VkMemoryPropertyFlags flags;
-    unsigned int i;
-    HRESULT hr;
-
-    if (FAILED(hr = vkd3d_select_memory_flags(device, heap_properties, &flags)))
-        return hr;
-
-    memory_type_mask &= vkd3d_select_memory_types(device, heap_flags);
-
-    for (i = 0; i < memory_info->memoryTypeCount; ++i)
-    {
-        if (!(memory_type_mask & (1u << i)))
-            continue;
-
-        if ((memory_info->memoryTypes[i].propertyFlags & flags) == flags)
-        {
-            *type_index = i;
-            return S_OK;
-        }
-    }
-
-    return E_FAIL;
-}
-
 static HRESULT vkd3d_try_allocate_memory(struct d3d12_device *device,
         VkDeviceSize size, VkMemoryPropertyFlags type_flags, uint32_t type_mask,
         void *pNext, VkDeviceMemory *vk_memory, uint32_t *vk_memory_type)

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -651,7 +651,7 @@ static HRESULT d3d12_heap_init(struct d3d12_heap *heap,
         if (d3d12_resource_is_buffer(resource))
         {
             hr = vkd3d_allocate_buffer_memory(device, resource->u.vk_buffer,
-                    &heap->desc.Properties, heap->desc.Flags,
+                    &heap->desc.Properties, heap->desc.Flags | D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS,
                     &heap->vk_memory, &heap->vk_memory_type, &vk_memory_size);
         }
         else
@@ -5251,7 +5251,7 @@ HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
             &resource_desc, &null_resources->vk_buffer)))
         goto fail;
     if (FAILED(hr = vkd3d_allocate_buffer_memory(device, null_resources->vk_buffer,
-            &heap_properties, D3D12_HEAP_FLAG_NONE, &null_resources->vk_buffer_memory, NULL, NULL)))
+            &heap_properties, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS, &null_resources->vk_buffer_memory, NULL, NULL)))
         goto fail;
     if (!vkd3d_create_vk_buffer_view(device, null_resources->vk_buffer,
             vkd3d_get_format(device, DXGI_FORMAT_R32_UINT, false),
@@ -5265,7 +5265,7 @@ HRESULT vkd3d_init_null_resources(struct vkd3d_null_resources *null_resources,
             &resource_desc, &null_resources->vk_storage_buffer)))
         goto fail;
     if (!use_sparse_resources && FAILED(hr = vkd3d_allocate_buffer_memory(device, null_resources->vk_storage_buffer,
-            &heap_properties, D3D12_HEAP_FLAG_NONE, &null_resources->vk_storage_buffer_memory, NULL, NULL)))
+            &heap_properties, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS, &null_resources->vk_storage_buffer_memory, NULL, NULL)))
         goto fail;
     if (!vkd3d_create_vk_buffer_view(device, null_resources->vk_storage_buffer,
             vkd3d_get_format(device, DXGI_FORMAT_R32_UINT, false),

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1448,6 +1448,16 @@ struct vkd3d_format_compatibility_list
     VkFormat vk_formats[VKD3D_MAX_COMPATIBLE_FORMAT_COUNT];
 };
 
+struct vkd3d_memory_info
+{
+    uint32_t buffer_type_mask;
+    uint32_t sampled_type_mask;
+    uint32_t rt_ds_type_mask;
+};
+
+HRESULT vkd3d_memory_info_init(struct vkd3d_memory_info *info,
+        struct d3d12_device *device) DECLSPEC_HIDDEN;
+
 /* meta operations */
 struct vkd3d_clear_uav_args
 {
@@ -1680,6 +1690,7 @@ struct d3d12_device
     const struct vkd3d_format_compatibility_list *format_compatibility_lists;
     struct vkd3d_null_resources null_resources;
     struct vkd3d_bindless_state bindless_state;
+    struct vkd3d_memory_info memory_info;
     struct vkd3d_meta_ops meta_ops;
 };
 

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -2377,6 +2377,16 @@ static void test_create_placed_resource(void)
             &IID_ID3D12Resource, (void **)&resource);
     ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
 
+    /* Textures are disallowed on ALLOW_ONLY_HEAPS */
+    resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    resource_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    resource_desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+
+    hr = ID3D12Device_CreatePlacedResource(device, heap, 0,
+            &resource_desc, D3D12_RESOURCE_STATE_COMMON, &clear_value,
+            &IID_ID3D12Resource, (void **)&resource);
+    ok(hr == E_INVALIDARG, "Got unexpected hr %#x.\n", hr);
+
     ID3D12Heap_Release(heap);
 
     for (i = 0; i < ARRAY_SIZE(invalid_buffer_desc_tests); ++i)


### PR DESCRIPTION
Currently, when allocating a D3D12 heap for placed resources, we just pick a memory type, hope that all resources are going to be supported on it, and fail if the corresponding Vulkan heap is full on some drivers (see #124). Also, we unconditionally report `D3D12_RESOURCE_HEAP_TIER_2` even on Tier 1 hardware.

As a solution, figure out which memory types support which type of resource and use that information to find compatible memory types, and iterate over compatible memory types until the allocation succeeds.

This needs a bit more testing and I'll probably have to revisit the usage flags for the dummy resources we use to gather the memory type information, but generally seems to work on both my RX 480 and RTX 2060 systems.