### PR TITLE
vkd3d: Serialize all queue submissions.

### DIFF
--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -1345,8 +1345,7 @@ struct d3d12_command_queue
     uint64_t drain_count;
     uint64_t queue_drain_count;
 
-    struct vkd3d_timeline_semaphore sparse_binding_wait;
-    struct vkd3d_timeline_semaphore sparse_binding_signal;
+    struct vkd3d_timeline_semaphore submit_timeline;
 
     struct vkd3d_private_store private_store;
 };


### PR DESCRIPTION
Gets rid of the full barrier on command buffer end.
Instead, do what D3D12 wants, which is to serialize all
ExecuteCommandLists. Simplify the existing timeline sempahore setup for
sparse queues and use it for all submissions.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>