### PR TITLE
Move to Meson build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ vkd3d-*.tar.xz
 .deps
 .dirstamp
 .libs
+build
+build.native
+build.cross

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "subprojects/dxil-spirv"]
+	path = subprojects/dxil-spirv
+	url = https://github.com/HansKristian-Work/dxil-spirv
+[submodule "subprojects/Vulkan-Headers"]
+	path = subprojects/Vulkan-Headers
+	url = https://github.com/KhronosGroup/Vulkan-Headers
+[submodule "subprojects/SPIRV-Headers"]
+	path = subprojects/SPIRV-Headers
+	url = https://github.com/KhronosGroup/SPIRV-Headers

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 AM_CFLAGS = @VKD3D_CFLAGS@
-AM_CPPFLAGS = -I$(srcdir)/include -I$(srcdir)/include/dummy -I$(srcdir)/include/private
+AM_CPPFLAGS = -I$(srcdir)/include -I$(srcdir)/include/dummy -I$(srcdir)/include/private -I$(srcdir)/subprojects/SPIRV-Headers/include -I$(srcdir)/subprojects/Vulkan-Headers/include
 AM_LDFLAGS = -no-undefined
 
 widl_headers = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
-AM_CFLAGS = @VKD3D_CFLAGS@
+AM_CFLAGS = @VKD3D_CFLAGS@ -DPACKAGE_VERSION=\"$(PACKAGE_VERSION)\" -D_GNU_SOURCE
 AM_CPPFLAGS = -I$(srcdir)/include -I$(srcdir)/include/dummy -I$(srcdir)/include/private -I$(srcdir)/subprojects/SPIRV-Headers/include -I$(srcdir)/subprojects/Vulkan-Headers/include
 AM_LDFLAGS = -no-undefined
 

--- a/build-win32.txt
+++ b/build-win32.txt
@@ -1,0 +1,19 @@
+[binaries]
+c = 'i686-w64-mingw32-gcc'
+cpp = 'i686-w64-mingw32-g++'
+ar = 'i686-w64-mingw32-ar'
+strip = 'i686-w64-mingw32-strip'
+cmake = 'i686-w64-mingw32-cmake'
+
+[properties]
+c_args=['-msse', '-msse2']
+cpp_args=['-msse', '-msse2']
+c_link_args = ['-static', '-static-libgcc']
+cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++']
+needs_exe_wrapper = true
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86'
+cpu = 'x86'
+endian = 'little'

--- a/build-win64.txt
+++ b/build-win64.txt
@@ -1,0 +1,17 @@
+[binaries]
+c = 'x86_64-w64-mingw32-gcc'
+cpp = 'x86_64-w64-mingw32-g++'
+ar = 'x86_64-w64-mingw32-ar'
+strip = 'x86_64-w64-mingw32-strip'
+cmake = 'x86_64-w64-mingw32-cmake'
+
+[properties]
+c_link_args = ['-static', '-static-libgcc']
+cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++']
+needs_exe_wrapper = true
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'

--- a/configure.ac
+++ b/configure.ac
@@ -58,27 +58,10 @@ VKD3D_CHECK_MINGW32_PROG([CROSSCC32], [CROSSTARGET32], [no])
 VKD3D_CHECK_MINGW64_PROG([CROSSCC64], [CROSSTARGET64], [no])
 
 dnl Check for headers
-AC_CHECK_HEADERS([dlfcn.h pthread.h \
-                  vulkan/vulkan.h \
-                  vulkan/spirv.h vulkan/GLSL.std.450.h \
-                  spirv/unified1/spirv.h spirv/unified1/GLSL.std.450.h])
+AC_CHECK_HEADERS([dlfcn.h pthread.h])
 AS_IF([test "x$ac_cv_header_pthread_h" != "xyes"], [AC_MSG_ERROR([pthread.h not found.])])
-AS_IF([test "x$ac_cv_header_vulkan_vulkan_h" != "xyes"], [AC_MSG_ERROR([vulkan.h not found.])])
-AS_IF([test "x$ac_cv_header_spirv_unified1_spirv_h" != "xyes" \
-       -a "x$ac_cv_header_vulkan_spirv_h" != "xyes"],
-      [AC_MSG_ERROR([spirv.h not found.])])
-AS_IF([test "x$ac_cv_header_spirv_unified1_GLSL_std_450_h" != "xyes" \
-       -a "x$ac_cv_header_vulkan_GLSL_std_450_h" != "xyes"],
-      [AC_MSG_ERROR([GLSL.std.450.h not found.])])
 
 VKD3D_CHECK_VULKAN_HEADER_VERSION([140], [AC_MSG_ERROR([Vulkan headers are too old, 1.2.140 is required.])])
-
-AC_CHECK_DECL([SpvCapabilityDemoteToHelperInvocationEXT],, [AC_MSG_ERROR([SPIR-V headers are too old.])], [
-#ifdef HAVE_SPIRV_UNIFIED1_SPIRV_H
-# include "spirv/unified1/spirv.h"
-#else
-# include "vulkan/spirv.h"
-#endif])
 
 AC_CHECK_DECLS([program_invocation_name],,,[#include <errno.h>])
 

--- a/demos/demo.h
+++ b/demos/demo.h
@@ -25,14 +25,6 @@
  * which leads to the "multiple storage classes in declaration
  * specifiers" compiler error.
  */
-#ifdef __MINGW32__
-#include <_mingw.h>
-# ifdef __MINGW64_VERSION_MAJOR
-#  undef __forceinline
-#  define __forceinline __inline__ __attribute__((__always_inline__,__gnu_inline__))
-# endif
-#endif
-
 #include <vkd3d_windows.h>
 #define WIDL_C_INLINE_WRAPPERS
 #define COBJMACROS

--- a/demos/meson.build
+++ b/demos/meson.build
@@ -1,0 +1,31 @@
+demo_vkd3d_deps = [
+  threads_dep
+]
+
+if vkd3d_platform != 'windows'
+  demo_vkd3d_deps += [
+    lib_m,
+    lib_xcb,
+    lib_xcbkeysyms,
+
+    vkd3d_dep,
+    vkd3d_utils_dep,
+  ]
+else
+  demo_vkd3d_deps += [
+    lib_dxgi,
+    lib_d3d12
+  ]
+endif
+
+executable('gears', 'gears.c', vkd3d_headers,
+  dependencies        : demo_vkd3d_deps,
+  install             : true,
+  gui_app             : true,
+  override_options    : [ 'c_std='+vkd3d_c_std ])
+
+executable('triangle', 'triangle.c', vkd3d_headers,
+  dependencies        : demo_vkd3d_deps,
+  install             : true,
+  gui_app             : true,
+  override_options    : [ 'c_std='+vkd3d_c_std ])

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,14 @@
+vkd3d_idl = [
+  'vkd3d_d3d12.idl',
+  'vkd3d_d3d12sdklayers.idl',
+  'vkd3d_d3dcommon.idl',
+  'vkd3d_dxgi.idl',
+  'vkd3d_dxgi1_2.idl',
+  'vkd3d_dxgi1_3.idl',
+  'vkd3d_dxgi1_4.idl',
+  'vkd3d_dxgibase.idl',
+  'vkd3d_dxgiformat.idl',
+  'vkd3d_dxgitype.idl',
+]
+
+vkd3d_headers = idl_generator.process(vkd3d_idl)

--- a/include/private/vkd3d_common.h
+++ b/include/private/vkd3d_common.h
@@ -19,7 +19,6 @@
 #ifndef __VKD3D_COMMON_H
 #define __VKD3D_COMMON_H
 
-#include "config.h"
 #include "vkd3d_windows.h"
 #include "vkd3d_spinlock.h"
 

--- a/include/private/vkd3d_threads.h
+++ b/include/private/vkd3d_threads.h
@@ -19,13 +19,9 @@
 #ifndef __VKD3D_THREADS_H
 #define __VKD3D_THREADS_H
 
-#include "config.h"
 #include "vkd3d_memory.h"
 
-#if defined(HAVE_PTHREAD_H)
-#include <pthread.h>
-
-#elif defined(_WIN32) /* HAVE_PTHREAD_H */
+#if defined(_WIN32)
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -147,21 +143,20 @@ static inline int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *lock)
     return ret ? 0 : -1;
 }
 
-#else /* HAVE_PTHREAD_H */
-#error "Threads are not supported. Cannot build."
-#endif /* HAVE_PTHREAD_H */
-
 static inline void vkd3d_set_thread_name(const char *name)
 {
-#if defined(_MSC_VER)
     (void)name;
-#elif defined(HAVE_PTHREAD_SETNAME_NP_2)
-    pthread_setname_np(pthread_self(), name);
-#elif defined(HAVE_PTHREAD_SETNAME_NP_1)
-    pthread_setname_np(name);
-#else
-    (void)name;
-#endif
 }
+#elif defined(__linux__)
+#include <pthread.h>
+static inline void vkd3d_set_thread_name(const char *name)
+{
+    pthread_setname_np(pthread_self(), name);
+}
+#else
+#error "Threads are not supported. Cannot build."
+#endif
+
+
 
 #endif /* __VKD3D_THREADS_H */

--- a/include/vkd3d_windows.h
+++ b/include/vkd3d_windows.h
@@ -155,7 +155,6 @@ extern "C++"
 typedef struct SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
 #endif  /* !defined(_WIN32) || defined(__WIDL__) */
 
-
 #ifndef _WIN32
 # include <stddef.h>
 # include <stdlib.h>

--- a/libs/meson.build
+++ b/libs/meson.build
@@ -1,0 +1,4 @@
+subdir('vkd3d-common')
+subdir('vkd3d-shader')
+subdir('vkd3d')
+subdir('vkd3d-utils')

--- a/libs/vkd3d-common/meson.build
+++ b/libs/vkd3d-common/meson.build
@@ -1,0 +1,13 @@
+vkd3d_common_src = [
+  'debug.c',
+  'memory.c',
+  'utf8.c',
+]
+
+vkd3d_common_lib = static_library('vkd3d_common', vkd3d_common_src,
+  include_directories : vkd3d_private_includes,
+  override_options    : [ 'c_std='+vkd3d_c_std ])
+
+vkd3d_common_dep = declare_dependency(
+  link_with           : vkd3d_common_lib,
+  include_directories : vkd3d_public_includes)

--- a/libs/vkd3d-shader/meson.build
+++ b/libs/vkd3d-shader/meson.build
@@ -1,0 +1,19 @@
+vkd3d_shader_src = [
+  'checksum.c',
+  'dxil.c',
+  'dxbc.c',
+  'spirv.c',
+  'trace.c',
+  'vkd3d_shader_main.c',
+]
+
+vkd3d_shader_lib = shared_library('vkd3d-shader', vkd3d_shader_src, vkd3d_headers,
+  dependencies        : [ vkd3d_common_dep, dxil_spirv_lib ],
+  include_directories : vkd3d_private_includes,
+  install             : true,
+  vs_module_defs      : 'vkd3d_shader.def',
+  override_options    : [ 'c_std='+vkd3d_c_std ])
+
+vkd3d_shader_dep = declare_dependency(
+  link_with           : vkd3d_shader_lib,
+  include_directories : vkd3d_public_includes)

--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -23,16 +23,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#ifdef HAVE_SPIRV_UNIFIED1_SPIRV_H
-# include "spirv/unified1/spirv.h"
-#else
-# include "vulkan/spirv.h"
-#endif  /* HAVE_SPIRV_UNIFIED1_SPIRV_H */
-#ifdef HAVE_SPIRV_UNIFIED1_GLSL_STD_450_H
-# include "spirv/unified1/GLSL.std.450.h"
-#else
-# include "vulkan/GLSL.std.450.h"
-#endif  /* HAVE_SPIRV_UNIFIED1_GLSL_STD_450_H */
+#include "spirv/unified1/spirv.h"
+#include "spirv/unified1/GLSL.std.450.h"
 
 #ifdef HAVE_SPIRV_TOOLS
 # include "spirv-tools/libspirv.h"

--- a/libs/vkd3d-shader/vkd3d_shader.def
+++ b/libs/vkd3d-shader/vkd3d_shader.def
@@ -1,0 +1,13 @@
+LIBRARY vkd3d-shader
+EXPORTS
+    vkd3d_shader_compile_dxbc
+    vkd3d_shader_convert_root_signature
+    vkd3d_shader_find_signature_element
+    vkd3d_shader_free_root_signature
+    vkd3d_shader_free_shader_code
+    vkd3d_shader_free_shader_signature
+    vkd3d_shader_parse_input_signature
+    vkd3d_shader_parse_root_signature
+    vkd3d_shader_scan_dxbc
+    vkd3d_shader_serialize_root_signature
+    vkd3d_shader_supports_dxil

--- a/libs/vkd3d-utils/meson.build
+++ b/libs/vkd3d-utils/meson.build
@@ -1,0 +1,14 @@
+vkd3d_utils_src = [
+  'vkd3d_utils_main.c',
+]
+
+vkd3d_utils_lib = shared_library('vkd3d-utils', vkd3d_utils_src, vkd3d_headers,
+  dependencies        : vkd3d_dep,
+  include_directories : vkd3d_private_includes,
+  install             : true,
+  vs_module_defs      : 'vkd3d_utils.def',
+  override_options    : [ 'c_std='+vkd3d_c_std ])
+
+vkd3d_utils_dep = declare_dependency(
+  link_with           : vkd3d_utils_lib,
+  include_directories : vkd3d_public_includes)

--- a/libs/vkd3d-utils/vkd3d_utils.def
+++ b/libs/vkd3d-utils/vkd3d_utils.def
@@ -1,0 +1,13 @@
+LIBRARY vkd3d-utils
+EXPORTS
+    D3D12CreateDevice
+    D3D12CreateRootSignatureDeserializer
+    D3D12CreateVersionedRootSignatureDeserializer
+    D3D12GetDebugInterface
+    D3D12SerializeRootSignature
+    D3D12SerializeVersionedRootSignature
+    vkd3d_create_event
+    vkd3d_destroy_event
+    vkd3d_signal_event
+    vkd3d_wait_event
+

--- a/libs/vkd3d/meson.build
+++ b/libs/vkd3d/meson.build
@@ -1,0 +1,23 @@
+vkd3d_src = [
+  'command.c',
+  'device.c',
+  'meta.c',
+  'platform.c',
+  'resource.c',
+  'state.c',
+  'utils.c',
+  'vkd3d_main.c',
+]
+
+vkd3d_lib = shared_library('vkd3d', vkd3d_src, vkd3d_version, vkd3d_headers,
+  dependencies        : [ vkd3d_common_dep, vkd3d_shader_dep ] + vkd3d_extra_libs,
+  include_directories : vkd3d_private_includes,
+  install             : true,
+  vs_module_defs      : 'vkd3d.def',
+  version             : '1.1.0',
+  override_options    : [ 'c_std='+vkd3d_c_std ])
+
+vkd3d_dep = declare_dependency(
+  link_with           : [ vkd3d_lib, vkd3d_common_lib ],
+  dependencies        : vkd3d_extra_libs,
+  include_directories : vkd3d_public_includes)

--- a/libs/vkd3d/vkd3d.def
+++ b/libs/vkd3d/vkd3d.def
@@ -1,0 +1,23 @@
+LIBRARY vkd3d
+EXPORTS
+    vkd3d_acquire_vk_queue
+    vkd3d_create_device
+    vkd3d_create_image_resource
+    vkd3d_create_instance
+    vkd3d_create_root_signature_deserializer
+    vkd3d_create_versioned_root_signature_deserializer
+    vkd3d_get_device_parent
+    vkd3d_get_dxgi_format
+    vkd3d_get_vk_device
+    vkd3d_get_vk_format
+    vkd3d_get_vk_physical_device
+    vkd3d_get_vk_queue_family_index
+    vkd3d_instance_decref
+    vkd3d_instance_from_device
+    vkd3d_instance_get_vk_instance
+    vkd3d_instance_incref
+    vkd3d_release_vk_queue
+    vkd3d_resource_decref
+    vkd3d_resource_incref
+    vkd3d_serialize_root_signature
+    vkd3d_serialize_versioned_root_signature

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,72 @@
+project('vkd3d', ['c'], version : '1.1', meson_version : '>= 0.51')
+
+cpu_family = target_machine.cpu_family()
+
+add_project_arguments('-DHAVE_DXIL_SPV', language : 'c')
+add_project_arguments('-D_GNU_SOURCE',   language : 'c')
+add_project_arguments('-DPACKAGE_VERSION="' + meson.project_version() + '"',   language : 'c')
+
+vkd3d_compiler = meson.get_compiler('c')
+vkd3d_c_std    = 'c99'
+
+vkd3d_external_includes = [ './subprojects/Vulkan-Headers/include', './subprojects/SPIRV-Headers/include' ]
+vkd3d_public_includes   = [ './include' ] + vkd3d_external_includes
+vkd3d_private_includes  = [ './include/private' ] + vkd3d_public_includes
+
+vkd3d_external_includes = include_directories(vkd3d_external_includes)
+vkd3d_public_includes   = include_directories(vkd3d_public_includes)
+vkd3d_private_includes  = include_directories(vkd3d_private_includes)
+
+idl_compiler  = find_program('widl')
+idl_generator = generator(idl_compiler,
+  output    : [ '@BASENAME@.h' ],
+  arguments : [ '-h', '-o', '@OUTPUT@', '@INPUT@' ])
+
+threads_dep = dependency('threads')
+
+vkd3d_platform = target_machine.system()
+if vkd3d_platform == 'linux'
+  lib_dl           = vkd3d_compiler.find_library('dl')
+  # For the demos...
+  lib_m            = vkd3d_compiler.find_library('m')
+  lib_xcb          = vkd3d_compiler.find_library('xcb')
+  lib_xcbkeysyms   = vkd3d_compiler.find_library('xcb-keysyms')
+  vkd3d_extra_libs = [ lib_dl, threads_dep ]
+elif vkd3d_platform == 'windows'
+  lib_dxgi         = vkd3d_compiler.find_library('dxgi')
+  lib_d3d12        = vkd3d_compiler.find_library('d3d12')
+  vkd3d_extra_libs = [ threads_dep ]
+else
+  error('Unknown platform')
+endif
+
+add_project_arguments(vkd3d_compiler.get_supported_arguments([
+    '-Wno-format',
+    '-Wno-discarded-qualifiers',
+    '-Wno-incompatible-pointer-types',
+    '-Wno-missing-braces']),
+  language : 'c')
+
+vkd3d_version = vcs_tag(
+  command : ['git', 'describe', '--dirty=+'],
+  input   : 'vkd3d_version.c.in',
+  output  : 'vkd3d_version.c')
+
+cmake = import('cmake')
+dxil_spirv = cmake.subproject('dxil-spirv', cmake_options: ['-DDXIL_SPIRV_CLI=OFF'] )
+dxil_spirv_lib = dxil_spirv.dependency('dxil-spirv-c-shared')
+
+subdir('include')
+subdir('libs')
+
+enable_tests  = get_option('enable_tests')
+enable_extras = get_option('enable_extras')
+
+if enable_tests
+  subdir('tests')
+endif
+
+if enable_extras
+  subdir('demos')
+  subdir('programs')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('enable_tests',  type : 'boolean', value : false)
+option('enable_extras', type : 'boolean', value : false)

--- a/programs/meson.build
+++ b/programs/meson.build
@@ -1,0 +1,1 @@
+subdir('vkd3d-compiler')

--- a/tests/d3d12_crosstest.h
+++ b/tests/d3d12_crosstest.h
@@ -19,22 +19,6 @@
 #ifndef __VKD3D_D3D12_CROSSTEST_H
 #define __VKD3D_D3D12_CROSSTEST_H
 
-/* Hack for MinGW-w64 headers.
- *
- * We want to use WIDL C inline wrappers because some methods
- * in D3D12 interfaces return aggregate objects. Unfortunately,
- * WIDL C inline wrappers are broken when used with MinGW-w64
- * headers because FORCEINLINE expands to extern inline
- * which leads to the "multiple storage classes in declaration
- * specifiers" compiler error.
- */
-#ifdef __MINGW32__
-# include <_mingw.h>
-# ifdef __MINGW64_VERSION_MAJOR
-#  undef __forceinline
-#  define __forceinline __inline__ __attribute__((__always_inline__,__gnu_inline__))
-# endif
-
 # define _HRESULT_DEFINED
 typedef int HRESULT;
 #endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,31 @@
+vkd3d_test_deps = [ vkd3d_dep, vkd3d_utils_dep ]
+
+executable('vkd3d_api', 'vkd3d_api.c', vkd3d_headers,
+  dependencies        : vkd3d_test_deps,
+  include_directories : vkd3d_private_includes,
+  install             : true,
+  override_options    : [ 'c_std='+vkd3d_c_std ])
+
+executable('vkd3d_common', 'vkd3d_common.c', vkd3d_headers,
+  dependencies        : vkd3d_test_deps,
+  include_directories : vkd3d_private_includes,
+  install             : true,
+  override_options    : [ 'c_std='+vkd3d_c_std ])
+
+executable('vkd3d_shader_api', 'vkd3d_shader_api.c', vkd3d_headers,
+  dependencies        : vkd3d_test_deps + [ vkd3d_shader_dep ],
+  include_directories : vkd3d_private_includes,
+  install             : true,
+  override_options    : [ 'c_std='+vkd3d_c_std ])
+
+executable('d3d12', 'd3d12.c', vkd3d_headers,
+  dependencies        : vkd3d_test_deps + [ vkd3d_shader_dep ],
+  include_directories : vkd3d_private_includes,
+  install             : true,
+  override_options    : [ 'c_std='+vkd3d_c_std ])
+
+executable('d3d12_invalid_usage', 'd3d12_invalid_usage.c', vkd3d_headers,
+  dependencies        : vkd3d_test_deps + [ vkd3d_shader_dep ],
+  include_directories : vkd3d_private_includes,
+  install             : true,
+  override_options    : [ 'c_std='+vkd3d_c_std ])

--- a/vkd3d_version.c.in
+++ b/vkd3d_version.c.in
@@ -1,0 +1,1 @@
+const char vkd3d_build[] = "@VCS_TAG@";


### PR DESCRIPTION
This moves VKD3D to build with the Meson build system.

This also builds dxil-spirv as a dependency, using Meson's CMake intergration.

This also makes vkd3d build fine on Windows, Native Linux and Cross-Building with MinGW64 :)

*(For cross-building vkd3d.dll with MinGW you will need to install mingw64-cmake in your package manager, fwiw chaotic-aur provides this package)*