### PR TITLE
vkd3d: Remove dependency on linking directly against libvulkan.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,8 @@ vkd3d_public_headers = \
 	include/vkd3d_shader.h \
 	include/vkd3d_types.h \
 	include/vkd3d_utils.h \
-	include/vkd3d_windows.h
+	include/vkd3d_windows.h \
+	include/vkd3d_sonames.h
 
 vkd3d_demos_shaders = \
 	demos/gears.hlsl \
@@ -156,14 +157,14 @@ AM_DEFAULT_SOURCE_EXT = .c
 if BUILD_TESTS
 check_PROGRAMS = $(vkd3d_tests) $(vkd3d_cross_tests)
 TESTS = $(vkd3d_tests) $(vkd3d_cross_tests)
-tests_d3d12_LDADD = $(LDADD) @PTHREAD_LIBS@ @VULKAN_LIBS@
-tests_d3d12_invalid_usage_LDADD = $(LDADD) @VULKAN_LIBS@
-tests_vkd3d_api_LDADD = libvkd3d.la @VULKAN_LIBS@
+tests_d3d12_LDADD = $(LDADD) @PTHREAD_LIBS@
+tests_d3d12_invalid_usage_LDADD = $(LDADD)
+tests_vkd3d_api_LDADD = libvkd3d.la
 tests_vkd3d_shader_api_LDADD = libvkd3d-shader.la
 endif
 
 if BUILD_DEMOS
-DEMOS_LDADD = $(LDADD) libvkd3d-shader.la @XCB_LIBS@ @VULKAN_LIBS@
+DEMOS_LDADD = $(LDADD) libvkd3d-shader.la @XCB_LIBS@ @DL_LIBS@
 DEMOS_CFLAGS = $(AM_CFLAGS) @XCB_CFLAGS@
 noinst_PROGRAMS += $(vkd3d_demos)
 

--- a/configure.ac
+++ b/configure.ac
@@ -95,14 +95,6 @@ AC_CHECK_LIB([dl], [dlopen],
 AC_ARG_VAR([PTHREAD_LIBS], [linker flags for pthreads])
 VKD3D_CHECK_PTHREAD
 
-AC_SUBST([VULKAN_LIBS])
-VKD3D_CHECK_SONAME([vulkan], [vkGetInstanceProcAddr],
-                   [VULKAN_LIBS="-lvulkan"],
-                   [VKD3D_CHECK_SONAME([MoltenVK], [vkGetInstanceProcAddr],
-                                       [VULKAN_LIBS="-lMoltenVK"
-                                       AC_DEFINE_UNQUOTED([SONAME_LIBVULKAN],["$ac_cv_lib_soname_MoltenVK"])],
-                                       [AC_MSG_ERROR([libvulkan and libMoltenVK not found.])])])
-
 AS_IF([test "x$with_spirv_tools" = "xyes"],
       [PKG_CHECK_MODULES([SPIRV_TOOLS], [SPIRV-Tools-shared],
       [AC_DEFINE([HAVE_SPIRV_TOOLS], [1], [Define to 1 if you have SPIRV-Tools.])])],

--- a/include/vkd3d_sonames.h
+++ b/include/vkd3d_sonames.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Hans-Kristian Arntzen for Valve Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef __VKD3D_SONAMES_H
+#define __VKD3D_SONAMES_H
+
+/* These sonames are defined by the loader ABI. */
+
+#if defined(_WIN32)
+#define SONAME_LIBVULKAN "vulkan-1.dll"
+#elif defined(__linux__)
+#define SONAME_LIBVULKAN "libvulkan.so.1"
+#elif defined(__APPLE__)
+#define SONAME_LIBVULKAN "libvulkan.1.dylib"
+#else
+#error "Unrecognized platform."
+#endif
+
+#endif
+

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -17,6 +17,7 @@
  */
 
 #include "vkd3d_private.h"
+#include "vkd3d_sonames.h"
 
 #ifdef HAVE_DLFCN_H
 #include <dlfcn.h>

--- a/tests/d3d12_crosstest.h
+++ b/tests/d3d12_crosstest.h
@@ -58,6 +58,7 @@ typedef int HRESULT;
 # include "vkd3d_threads.h"
 # include "vkd3d.h"
 # include "vkd3d_utils.h"
+# include "vkd3d_sonames.h"
 #endif
 
 #if !defined(_WIN32)
@@ -418,7 +419,7 @@ static bool init_vulkan_loader(void)
         return true;
 
 #ifdef _WIN32
-    HMODULE mod = LoadLibrary(SONAME_LIBVULKAN);
+    HMODULE mod = LoadLibraryA(SONAME_LIBVULKAN);
     if (!mod)
         return false;
 


### PR DESCRIPTION
There is no reason to not load Vulkan dynamically, otherwise, we must
have loader dev packages installed, which is not ideal.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>