### PR TITLE
Make nameless unions really nameless

### DIFF
--- a/include/vkd3d_shader.h
+++ b/include/vkd3d_shader.h
@@ -117,7 +117,7 @@ struct vkd3d_shader_parameter_immediate_constant
     union
     {
         uint32_t u32;
-    } u;
+    };
 };
 
 struct vkd3d_shader_parameter_specialization_constant
@@ -134,7 +134,7 @@ struct vkd3d_shader_parameter
     {
         struct vkd3d_shader_parameter_immediate_constant immediate_constant;
         struct vkd3d_shader_parameter_specialization_constant specialization_constant;
-    } u;
+    };
 };
 
 #define VKD3D_SHADER_DESCRIPTOR_RANGE_UNBOUNDED (~0u)
@@ -426,7 +426,7 @@ struct vkd3d_root_parameter
         struct vkd3d_root_descriptor_table descriptor_table;
         struct vkd3d_root_constants constants;
         struct vkd3d_root_descriptor descriptor;
-    } u;
+    };
     enum vkd3d_shader_visibility shader_visibility;
 };
 
@@ -502,7 +502,7 @@ struct vkd3d_root_parameter1
         struct vkd3d_root_descriptor_table1 descriptor_table;
         struct vkd3d_root_constants constants;
         struct vkd3d_root_descriptor1 descriptor;
-    } u;
+    };
     enum vkd3d_shader_visibility shader_visibility;
 };
 
@@ -530,7 +530,7 @@ struct vkd3d_versioned_root_signature_desc
     {
         struct vkd3d_root_signature_desc v_1_0;
         struct vkd3d_root_signature_desc1 v_1_1;
-    } u;
+    };
 };
 
 /* FIXME: Add support for 64 UAV bind slots. */

--- a/include/vkd3d_windows.h
+++ b/include/vkd3d_windows.h
@@ -22,13 +22,8 @@
 
 /* Nameless unions */
 #ifndef __C89_NAMELESS
-# ifdef NONAMELESSUNION
-#  define __C89_NAMELESS
-#  define __C89_NAMELESSUNIONNAME u
-# else
 #  define __C89_NAMELESS
 #  define __C89_NAMELESSUNIONNAME
-# endif /* NONAMELESSUNION */
 #endif  /* __C89_NAMELESS */
 
 #if !defined(_WIN32) || defined(__WIDL__)

--- a/libs/vkd3d-shader/dxbc.c
+++ b/libs/vkd3d-shader/dxbc.c
@@ -804,7 +804,7 @@ static void shader_sm5_read_fcall(struct vkd3d_shader_instruction *ins,
         DWORD opcode, DWORD opcode_token, const DWORD *tokens, unsigned int token_count,
         struct vkd3d_sm4_data *priv)
 {
-    priv->src_param[0].reg.u.fp_body_idx = *tokens++;
+    priv->src_param[0].reg.fp_body_idx = *tokens++;
     shader_sm4_read_src_param(priv, &tokens, &tokens[token_count], VKD3D_DATA_OPAQUE, &priv->src_param[0]);
 }
 
@@ -1624,7 +1624,7 @@ static bool shader_sm4_read_param(struct vkd3d_sm4_data *priv, const DWORD **ptr
                     WARN("Invalid ptr %p, end %p.\n", *ptr, end);
                     return false;
                 }
-                memcpy(param->u.immconst_uint, *ptr, 1 * sizeof(DWORD));
+                memcpy(param->immconst_uint, *ptr, 1 * sizeof(DWORD));
                 *ptr += 1;
                 break;
 
@@ -1635,7 +1635,7 @@ static bool shader_sm4_read_param(struct vkd3d_sm4_data *priv, const DWORD **ptr
                     WARN("Invalid ptr %p, end %p.\n", *ptr, end);
                     return false;
                 }
-                memcpy(param->u.immconst_uint, *ptr, VKD3D_VEC4_SIZE * sizeof(DWORD));
+                memcpy(param->immconst_uint, *ptr, VKD3D_VEC4_SIZE * sizeof(DWORD));
                 *ptr += 4;
                 break;
 
@@ -2515,15 +2515,15 @@ static int shader_parse_root_parameters(struct root_signature_parser_context *co
         switch (parameters[i].parameter_type)
         {
             case VKD3D_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
-                ret = shader_parse_descriptor_table(context, offset, &parameters[i].u.descriptor_table);
+                ret = shader_parse_descriptor_table(context, offset, &parameters[i].descriptor_table);
                 break;
             case VKD3D_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
-                ret = shader_parse_root_constants(context, offset, &parameters[i].u.constants);
+                ret = shader_parse_root_constants(context, offset, &parameters[i].constants);
                 break;
             case VKD3D_ROOT_PARAMETER_TYPE_CBV:
             case VKD3D_ROOT_PARAMETER_TYPE_SRV:
             case VKD3D_ROOT_PARAMETER_TYPE_UAV:
-                ret = shader_parse_root_descriptor(context, offset, &parameters[i].u.descriptor);
+                ret = shader_parse_root_descriptor(context, offset, &parameters[i].descriptor);
                 break;
             default:
                 FIXME("Unrecognized type %#x.\n", parameters[i].parameter_type);
@@ -2563,15 +2563,15 @@ static int shader_parse_root_parameters1(struct root_signature_parser_context *c
         switch (parameters[i].parameter_type)
         {
             case VKD3D_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
-                ret = shader_parse_descriptor_table1(context, offset, &parameters[i].u.descriptor_table);
+                ret = shader_parse_descriptor_table1(context, offset, &parameters[i].descriptor_table);
                 break;
             case VKD3D_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
-                ret = shader_parse_root_constants(context, offset, &parameters[i].u.constants);
+                ret = shader_parse_root_constants(context, offset, &parameters[i].constants);
                 break;
             case VKD3D_ROOT_PARAMETER_TYPE_CBV:
             case VKD3D_ROOT_PARAMETER_TYPE_SRV:
             case VKD3D_ROOT_PARAMETER_TYPE_UAV:
-                ret = shader_parse_root_descriptor1(context, offset, &parameters[i].u.descriptor);
+                ret = shader_parse_root_descriptor1(context, offset, &parameters[i].descriptor);
                 break;
             default:
                 FIXME("Unrecognized type %#x.\n", parameters[i].parameter_type);
@@ -2621,7 +2621,7 @@ static int shader_parse_static_samplers(struct root_signature_parser_context *co
 static int shader_parse_root_signature(const char *data, unsigned int data_size,
         struct vkd3d_versioned_root_signature_desc *desc)
 {
-    struct vkd3d_root_signature_desc *v_1_0 = &desc->u.v_1_0;
+    struct vkd3d_root_signature_desc *v_1_0 = &desc->v_1_0;
     struct root_signature_parser_context context;
     unsigned int count, offset, version;
     const char *ptr = data;
@@ -2664,7 +2664,7 @@ static int shader_parse_root_signature(const char *data, unsigned int data_size,
     }
     else
     {
-        struct vkd3d_root_signature_desc1 *v_1_1 = &desc->u.v_1_1;
+        struct vkd3d_root_signature_desc1 *v_1_1 = &desc->v_1_1;
 
         assert(version == VKD3D_ROOT_SIGNATURE_VERSION_1_1);
 
@@ -2731,61 +2731,61 @@ int vkd3d_shader_parse_root_signature(const struct vkd3d_shader_code *dxbc,
 static unsigned int versioned_root_signature_get_parameter_count(const struct vkd3d_versioned_root_signature_desc *desc)
 {
     if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_0)
-        return desc->u.v_1_0.parameter_count;
+        return desc->v_1_0.parameter_count;
     else
-        return desc->u.v_1_1.parameter_count;
+        return desc->v_1_1.parameter_count;
 }
 
 static enum vkd3d_root_parameter_type versioned_root_signature_get_parameter_type(
         const struct vkd3d_versioned_root_signature_desc *desc, unsigned int i)
 {
     if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_0)
-        return desc->u.v_1_0.parameters[i].parameter_type;
+        return desc->v_1_0.parameters[i].parameter_type;
     else
-        return desc->u.v_1_1.parameters[i].parameter_type;
+        return desc->v_1_1.parameters[i].parameter_type;
 }
 
 static enum vkd3d_shader_visibility versioned_root_signature_get_parameter_shader_visibility(
         const struct vkd3d_versioned_root_signature_desc *desc, unsigned int i)
 {
     if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_0)
-        return desc->u.v_1_0.parameters[i].shader_visibility;
+        return desc->v_1_0.parameters[i].shader_visibility;
     else
-        return desc->u.v_1_1.parameters[i].shader_visibility;
+        return desc->v_1_1.parameters[i].shader_visibility;
 }
 
 static const struct vkd3d_root_constants *versioned_root_signature_get_root_constants(
         const struct vkd3d_versioned_root_signature_desc *desc, unsigned int i)
 {
     if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_0)
-        return &desc->u.v_1_0.parameters[i].u.constants;
+        return &desc->v_1_0.parameters[i].constants;
     else
-        return &desc->u.v_1_1.parameters[i].u.constants;
+        return &desc->v_1_1.parameters[i].constants;
 }
 
 static unsigned int versioned_root_signature_get_static_sampler_count(const struct vkd3d_versioned_root_signature_desc *desc)
 {
     if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_0)
-        return desc->u.v_1_0.static_sampler_count;
+        return desc->v_1_0.static_sampler_count;
     else
-        return desc->u.v_1_1.static_sampler_count;
+        return desc->v_1_1.static_sampler_count;
 }
 
 static const struct vkd3d_static_sampler_desc *versioned_root_signature_get_static_samplers(
         const struct vkd3d_versioned_root_signature_desc *desc)
 {
     if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_0)
-        return desc->u.v_1_0.static_samplers;
+        return desc->v_1_0.static_samplers;
     else
-        return desc->u.v_1_1.static_samplers;
+        return desc->v_1_1.static_samplers;
 }
 
 static unsigned int versioned_root_signature_get_flags(const struct vkd3d_versioned_root_signature_desc *desc)
 {
     if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_0)
-        return desc->u.v_1_0.flags;
+        return desc->v_1_0.flags;
     else
-        return desc->u.v_1_1.flags;
+        return desc->v_1_1.flags;
 }
 
 struct root_signature_writer_context
@@ -2998,9 +2998,9 @@ static int shader_write_root_parameters(struct root_signature_writer_context *co
         {
             case VKD3D_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
                 if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_0)
-                    ret = shader_write_descriptor_table(context, &desc->u.v_1_0.parameters[i].u.descriptor_table);
+                    ret = shader_write_descriptor_table(context, &desc->v_1_0.parameters[i].descriptor_table);
                 else
-                    ret = shader_write_descriptor_table1(context, &desc->u.v_1_1.parameters[i].u.descriptor_table);
+                    ret = shader_write_descriptor_table1(context, &desc->v_1_1.parameters[i].descriptor_table);
                 break;
             case VKD3D_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
                 ret = shader_write_root_constants(context, versioned_root_signature_get_root_constants(desc, i));
@@ -3009,9 +3009,9 @@ static int shader_write_root_parameters(struct root_signature_writer_context *co
             case VKD3D_ROOT_PARAMETER_TYPE_SRV:
             case VKD3D_ROOT_PARAMETER_TYPE_UAV:
                 if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_0)
-                    ret = shader_write_root_descriptor(context, &desc->u.v_1_0.parameters[i].u.descriptor);
+                    ret = shader_write_root_descriptor(context, &desc->v_1_0.parameters[i].descriptor);
                 else
-                    ret = shader_write_root_descriptor1(context, &desc->u.v_1_1.parameters[i].u.descriptor);
+                    ret = shader_write_root_descriptor1(context, &desc->v_1_1.parameters[i].descriptor);
                 break;
             default:
                 FIXME("Unrecognized type %#x.\n", versioned_root_signature_get_parameter_type(desc, i));
@@ -3179,9 +3179,9 @@ static int validate_root_signature_desc(const struct vkd3d_versioned_root_signat
         if (type == VKD3D_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
         {
             if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_0)
-                ret = validate_descriptor_table_v_1_0(&desc->u.v_1_0.parameters[i].u.descriptor_table);
+                ret = validate_descriptor_table_v_1_0(&desc->v_1_0.parameters[i].descriptor_table);
             else
-                ret = validate_descriptor_table_v_1_1(&desc->u.v_1_1.parameters[i].u.descriptor_table);
+                ret = validate_descriptor_table_v_1_1(&desc->v_1_1.parameters[i].descriptor_table);
         }
 
         if (ret < 0)
@@ -3251,7 +3251,7 @@ static void free_descriptor_ranges(const struct vkd3d_root_parameter *parameters
         const struct vkd3d_root_parameter *p = &parameters[i];
 
         if (p->parameter_type == VKD3D_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
-            vkd3d_free((void *)p->u.descriptor_table.descriptor_ranges);
+            vkd3d_free((void *)p->descriptor_table.descriptor_ranges);
     }
 }
 
@@ -3273,17 +3273,17 @@ static int convert_root_parameters_to_v_1_0(struct vkd3d_root_parameter *dst,
         {
             case VKD3D_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
                 ranges = NULL;
-                if ((p->u.descriptor_table.descriptor_range_count = p1->u.descriptor_table.descriptor_range_count))
+                if ((p->descriptor_table.descriptor_range_count = p1->descriptor_table.descriptor_range_count))
                 {
-                    if (!(ranges = vkd3d_calloc(p->u.descriptor_table.descriptor_range_count, sizeof(*ranges))))
+                    if (!(ranges = vkd3d_calloc(p->descriptor_table.descriptor_range_count, sizeof(*ranges))))
                     {
                         ret = VKD3D_ERROR_OUT_OF_MEMORY;
                         goto fail;
                     }
                 }
-                p->u.descriptor_table.descriptor_ranges = ranges;
-                ranges1 = p1->u.descriptor_table.descriptor_ranges;
-                for (j = 0; j < p->u.descriptor_table.descriptor_range_count; ++j)
+                p->descriptor_table.descriptor_ranges = ranges;
+                ranges1 = p1->descriptor_table.descriptor_ranges;
+                for (j = 0; j < p->descriptor_table.descriptor_range_count; ++j)
                 {
                     ranges[j].range_type = ranges1[j].range_type;
                     ranges[j].descriptor_count = ranges1[j].descriptor_count;
@@ -3293,13 +3293,13 @@ static int convert_root_parameters_to_v_1_0(struct vkd3d_root_parameter *dst,
                 }
                 break;
             case VKD3D_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
-                p->u.constants = p1->u.constants;
+                p->constants = p1->constants;
                 break;
             case VKD3D_ROOT_PARAMETER_TYPE_CBV:
             case VKD3D_ROOT_PARAMETER_TYPE_SRV:
             case VKD3D_ROOT_PARAMETER_TYPE_UAV:
-                p->u.descriptor.shader_register = p1->u.descriptor.shader_register;
-                p->u.descriptor.register_space = p1->u.descriptor.register_space;
+                p->descriptor.shader_register = p1->descriptor.shader_register;
+                p->descriptor.register_space = p1->descriptor.register_space;
                 break;
             default:
                 WARN("Invalid root parameter type %#x.\n", p->parameter_type);
@@ -3320,8 +3320,8 @@ fail:
 static int convert_root_signature_to_v1_0(struct vkd3d_versioned_root_signature_desc *dst,
         const struct vkd3d_versioned_root_signature_desc *src)
 {
-    const struct vkd3d_root_signature_desc1 *src_desc = &src->u.v_1_1;
-    struct vkd3d_root_signature_desc *dst_desc = &dst->u.v_1_0;
+    const struct vkd3d_root_signature_desc1 *src_desc = &src->v_1_1;
+    struct vkd3d_root_signature_desc *dst_desc = &dst->v_1_0;
     struct vkd3d_static_sampler_desc *samplers = NULL;
     struct vkd3d_root_parameter *parameters = NULL;
     int ret;
@@ -3370,7 +3370,7 @@ static void free_descriptor_ranges1(const struct vkd3d_root_parameter1 *paramete
         const struct vkd3d_root_parameter1 *p = &parameters[i];
 
         if (p->parameter_type == VKD3D_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
-            vkd3d_free((void *)p->u.descriptor_table.descriptor_ranges);
+            vkd3d_free((void *)p->descriptor_table.descriptor_ranges);
     }
 }
 
@@ -3392,17 +3392,17 @@ static int convert_root_parameters_to_v_1_1(struct vkd3d_root_parameter1 *dst,
         {
             case VKD3D_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
                 ranges1 = NULL;
-                if ((p1->u.descriptor_table.descriptor_range_count = p->u.descriptor_table.descriptor_range_count))
+                if ((p1->descriptor_table.descriptor_range_count = p->descriptor_table.descriptor_range_count))
                 {
-                    if (!(ranges1 = vkd3d_calloc(p1->u.descriptor_table.descriptor_range_count, sizeof(*ranges1))))
+                    if (!(ranges1 = vkd3d_calloc(p1->descriptor_table.descriptor_range_count, sizeof(*ranges1))))
                     {
                         ret = VKD3D_ERROR_OUT_OF_MEMORY;
                         goto fail;
                     }
                 }
-                p1->u.descriptor_table.descriptor_ranges = ranges1;
-                ranges = p->u.descriptor_table.descriptor_ranges;
-                for (j = 0; j < p1->u.descriptor_table.descriptor_range_count; ++j)
+                p1->descriptor_table.descriptor_ranges = ranges1;
+                ranges = p->descriptor_table.descriptor_ranges;
+                for (j = 0; j < p1->descriptor_table.descriptor_range_count; ++j)
                 {
                     ranges1[j].range_type = ranges[j].range_type;
                     ranges1[j].descriptor_count = ranges[j].descriptor_count;
@@ -3413,14 +3413,14 @@ static int convert_root_parameters_to_v_1_1(struct vkd3d_root_parameter1 *dst,
                 }
                 break;
             case VKD3D_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
-                p1->u.constants = p->u.constants;
+                p1->constants = p->constants;
                 break;
             case VKD3D_ROOT_PARAMETER_TYPE_CBV:
             case VKD3D_ROOT_PARAMETER_TYPE_SRV:
             case VKD3D_ROOT_PARAMETER_TYPE_UAV:
-                p1->u.descriptor.shader_register = p->u.descriptor.shader_register;
-                p1->u.descriptor.register_space = p->u.descriptor.register_space;
-                p1->u.descriptor.flags = VKD3D_ROOT_SIGNATURE_1_0_ROOT_DESCRIPTOR_FLAGS;
+                p1->descriptor.shader_register = p->descriptor.shader_register;
+                p1->descriptor.register_space = p->descriptor.register_space;
+                p1->descriptor.flags = VKD3D_ROOT_SIGNATURE_1_0_ROOT_DESCRIPTOR_FLAGS;
                 break;
             default:
                 WARN("Invalid root parameter type %#x.\n", p1->parameter_type);
@@ -3441,8 +3441,8 @@ fail:
 static int convert_root_signature_to_v1_1(struct vkd3d_versioned_root_signature_desc *dst,
         const struct vkd3d_versioned_root_signature_desc *src)
 {
-    const struct vkd3d_root_signature_desc *src_desc = &src->u.v_1_0;
-    struct vkd3d_root_signature_desc1 *dst_desc = &dst->u.v_1_1;
+    const struct vkd3d_root_signature_desc *src_desc = &src->v_1_0;
+    struct vkd3d_root_signature_desc1 *dst_desc = &dst->v_1_1;
     struct vkd3d_static_sampler_desc *samplers = NULL;
     struct vkd3d_root_parameter1 *parameters = NULL;
     int ret;

--- a/libs/vkd3d-shader/dxil.c
+++ b/libs/vkd3d-shader/dxil.c
@@ -501,7 +501,7 @@ int vkd3d_shader_compile_dxil(const struct vkd3d_shader_code *dxbc,
                 bool spec_constant = argument->type == VKD3D_SHADER_PARAMETER_TYPE_SPECIALIZATION_CONSTANT;
                 const dxil_spv_option_rasterizer_sample_count helper =
                         { { DXIL_SPV_OPTION_RASTERIZER_SAMPLE_COUNT },
-                          spec_constant ? argument->u.specialization_constant.id : argument->u.immediate_constant.u.u32,
+                          spec_constant ? argument->specialization_constant.id : argument->immediate_constant.u32,
                           spec_constant ? DXIL_SPV_TRUE : DXIL_SPV_FALSE };
                 if (dxil_spv_converter_add_option(converter, &helper.base) != DXIL_SPV_SUCCESS)
                 {

--- a/libs/vkd3d-shader/trace.c
+++ b/libs/vkd3d-shader/trace.c
@@ -970,15 +970,15 @@ static void shader_dump_register(struct vkd3d_string_buffer *buffer,
                 switch (reg->data_type)
                 {
                     case VKD3D_DATA_FLOAT:
-                        shader_addline(buffer, "%.8e", reg->u.immconst_float[0]);
+                        shader_addline(buffer, "%.8e", reg->immconst_float[0]);
                         break;
                     case VKD3D_DATA_INT:
-                        shader_addline(buffer, "%d", reg->u.immconst_uint[0]);
+                        shader_addline(buffer, "%d", reg->immconst_uint[0]);
                         break;
                     case VKD3D_DATA_RESOURCE:
                     case VKD3D_DATA_SAMPLER:
                     case VKD3D_DATA_UINT:
-                        shader_addline(buffer, "%u", reg->u.immconst_uint[0]);
+                        shader_addline(buffer, "%u", reg->immconst_uint[0]);
                         break;
                     default:
                         shader_addline(buffer, "<unhandled data type %#x>", reg->data_type);
@@ -991,20 +991,20 @@ static void shader_dump_register(struct vkd3d_string_buffer *buffer,
                 {
                     case VKD3D_DATA_FLOAT:
                         shader_addline(buffer, "%.8e, %.8e, %.8e, %.8e",
-                                reg->u.immconst_float[0], reg->u.immconst_float[1],
-                                reg->u.immconst_float[2], reg->u.immconst_float[3]);
+                                reg->immconst_float[0], reg->immconst_float[1],
+                                reg->immconst_float[2], reg->immconst_float[3]);
                         break;
                     case VKD3D_DATA_INT:
                         shader_addline(buffer, "%d, %d, %d, %d",
-                                reg->u.immconst_uint[0], reg->u.immconst_uint[1],
-                                reg->u.immconst_uint[2], reg->u.immconst_uint[3]);
+                                reg->immconst_uint[0], reg->immconst_uint[1],
+                                reg->immconst_uint[2], reg->immconst_uint[3]);
                         break;
                     case VKD3D_DATA_RESOURCE:
                     case VKD3D_DATA_SAMPLER:
                     case VKD3D_DATA_UINT:
                         shader_addline(buffer, "%u, %u, %u, %u",
-                                reg->u.immconst_uint[0], reg->u.immconst_uint[1],
-                                reg->u.immconst_uint[2], reg->u.immconst_uint[3]);
+                                reg->immconst_uint[0], reg->immconst_uint[1],
+                                reg->immconst_uint[2], reg->immconst_uint[3]);
                         break;
                     default:
                         shader_addline(buffer, "<unhandled data type %#x>", reg->data_type);
@@ -1056,7 +1056,7 @@ static void shader_dump_register(struct vkd3d_string_buffer *buffer,
         }
 
         if (reg->type == VKD3DSPR_FUNCTIONPOINTER)
-            shader_addline(buffer, "[%u]", reg->u.fp_body_idx);
+            shader_addline(buffer, "[%u]", reg->fp_body_idx);
     }
 }
 
@@ -1553,19 +1553,19 @@ static void shader_dump_instruction(struct vkd3d_string_buffer *buffer,
         case VKD3DSIH_DEF:
             shader_addline(buffer, "def c%u = %.8e, %.8e, %.8e, %.8e",
                     shader_get_float_offset(ins->dst[0].reg.type, ins->dst[0].reg.idx[0].offset),
-                    ins->src[0].reg.u.immconst_float[0], ins->src[0].reg.u.immconst_float[1],
-                    ins->src[0].reg.u.immconst_float[2], ins->src[0].reg.u.immconst_float[3]);
+                    ins->src[0].reg.immconst_float[0], ins->src[0].reg.immconst_float[1],
+                    ins->src[0].reg.immconst_float[2], ins->src[0].reg.immconst_float[3]);
             break;
 
         case VKD3DSIH_DEFI:
             shader_addline(buffer, "defi i%u = %d, %d, %d, %d", ins->dst[0].reg.idx[0].offset,
-                    ins->src[0].reg.u.immconst_uint[0], ins->src[0].reg.u.immconst_uint[1],
-                    ins->src[0].reg.u.immconst_uint[2], ins->src[0].reg.u.immconst_uint[3]);
+                    ins->src[0].reg.immconst_uint[0], ins->src[0].reg.immconst_uint[1],
+                    ins->src[0].reg.immconst_uint[2], ins->src[0].reg.immconst_uint[3]);
             break;
 
         case VKD3DSIH_DEFB:
             shader_addline(buffer, "defb b%u = %s",
-                    ins->dst[0].reg.idx[0].offset, ins->src[0].reg.u.immconst_uint[0] ? "true" : "false");
+                    ins->dst[0].reg.idx[0].offset, ins->src[0].reg.immconst_uint[0] ? "true" : "false");
             break;
 
         default:

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -372,7 +372,7 @@ static void vkd3d_shader_free_root_signature_v_1_0(struct vkd3d_root_signature_d
         const struct vkd3d_root_parameter *parameter = &root_signature->parameters[i];
 
         if (parameter->parameter_type == VKD3D_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
-            vkd3d_free((void *)parameter->u.descriptor_table.descriptor_ranges);
+            vkd3d_free((void *)parameter->descriptor_table.descriptor_ranges);
     }
     vkd3d_free((void *)root_signature->parameters);
     vkd3d_free((void *)root_signature->static_samplers);
@@ -389,7 +389,7 @@ static void vkd3d_shader_free_root_signature_v_1_1(struct vkd3d_root_signature_d
         const struct vkd3d_root_parameter1 *parameter = &root_signature->parameters[i];
 
         if (parameter->parameter_type == VKD3D_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
-            vkd3d_free((void *)parameter->u.descriptor_table.descriptor_ranges);
+            vkd3d_free((void *)parameter->descriptor_table.descriptor_ranges);
     }
     vkd3d_free((void *)root_signature->parameters);
     vkd3d_free((void *)root_signature->static_samplers);
@@ -401,11 +401,11 @@ void vkd3d_shader_free_root_signature(struct vkd3d_versioned_root_signature_desc
 {
     if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_0)
     {
-        vkd3d_shader_free_root_signature_v_1_0(&desc->u.v_1_0);
+        vkd3d_shader_free_root_signature_v_1_0(&desc->v_1_0);
     }
     else if (desc->version == VKD3D_ROOT_SIGNATURE_VERSION_1_1)
     {
-        vkd3d_shader_free_root_signature_v_1_1(&desc->u.v_1_1);
+        vkd3d_shader_free_root_signature_v_1_1(&desc->v_1_1);
     }
     else if (desc->version)
     {

--- a/libs/vkd3d-shader/vkd3d_shader_private.h
+++ b/libs/vkd3d-shader/vkd3d_shader_private.h
@@ -45,7 +45,6 @@
 #ifndef __VKD3D_SHADER_PRIVATE_H
 #define __VKD3D_SHADER_PRIVATE_H
 
-#define NONAMELESSUNION
 #include "vkd3d_common.h"
 #include "vkd3d_memory.h"
 #include "vkd3d_shader.h"
@@ -589,7 +588,7 @@ struct vkd3d_shader_register
         DWORD immconst_uint[VKD3D_VEC4_SIZE];
         float immconst_float[VKD3D_VEC4_SIZE];
         unsigned fp_body_idx;
-    } u;
+    };
 };
 
 struct vkd3d_shader_dst_param

--- a/libs/vkd3d-utils/vkd3d_utils_private.h
+++ b/libs/vkd3d-utils/vkd3d_utils_private.h
@@ -20,7 +20,6 @@
 #define __VKD3D_UTILS_PRIVATE_H
 
 #define COBJMACROS
-#define NONAMELESSUNION
 #define VK_NO_PROTOTYPES
 
 #include "vkd3d_threads.h"

--- a/libs/vkd3d/state.c
+++ b/libs/vkd3d/state.c
@@ -489,9 +489,9 @@ static HRESULT d3d12_root_signature_info_from_desc(struct d3d12_root_signature_i
         switch (p->ParameterType)
         {
             case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
-                for (j = 0; j < p->u.DescriptorTable.NumDescriptorRanges; ++j)
+                for (j = 0; j < p->DescriptorTable.NumDescriptorRanges; ++j)
                     if (FAILED(hr = d3d12_root_signature_info_count_descriptors(info,
-                            device, &p->u.DescriptorTable.pDescriptorRanges[j])))
+                            device, &p->DescriptorTable.pDescriptorRanges[j])))
                         return hr;
                 info->cost += 1;
                 break;
@@ -506,7 +506,7 @@ static HRESULT d3d12_root_signature_info_from_desc(struct d3d12_root_signature_i
 
             case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
                 info->root_constant_count += 1;
-                info->cost += p->u.Constants.Num32BitValues;
+                info->cost += p->Constants.Num32BitValues;
                 break;
 
             default:
@@ -544,16 +544,16 @@ static HRESULT d3d12_root_signature_init_push_constants(struct d3d12_root_signat
         root_signature->root_constant_mask |= 1ull << i;
 
         root_signature->parameters[i].parameter_type = p->ParameterType;
-        root_signature->parameters[i].u.constant.constant_index = push_constant_range->size / sizeof(uint32_t);
-        root_signature->parameters[i].u.constant.constant_count = p->u.Constants.Num32BitValues;
+        root_signature->parameters[i].constant.constant_index = push_constant_range->size / sizeof(uint32_t);
+        root_signature->parameters[i].constant.constant_count = p->Constants.Num32BitValues;
 
-        root_signature->root_constants[j].register_space = p->u.Constants.RegisterSpace;
-        root_signature->root_constants[j].register_index = p->u.Constants.ShaderRegister;
+        root_signature->root_constants[j].register_space = p->Constants.RegisterSpace;
+        root_signature->root_constants[j].register_index = p->Constants.ShaderRegister;
         root_signature->root_constants[j].shader_visibility = vkd3d_shader_visibility_from_d3d12(p->ShaderVisibility);
         root_signature->root_constants[j].offset = push_constant_range->size;
-        root_signature->root_constants[j].size = p->u.Constants.Num32BitValues * sizeof(uint32_t);
+        root_signature->root_constants[j].size = p->Constants.Num32BitValues * sizeof(uint32_t);
 
-        push_constant_range->size += p->u.Constants.Num32BitValues * sizeof(uint32_t);
+        push_constant_range->size += p->Constants.Num32BitValues * sizeof(uint32_t);
 
         ++j;
     }
@@ -609,8 +609,8 @@ static HRESULT d3d12_root_signature_init_root_descriptor_tables(struct d3d12_roo
 
         root_signature->descriptor_table_mask |= 1ull << i;
 
-        table = &root_signature->parameters[i].u.descriptor_table;
-        range_count = p->u.DescriptorTable.NumDescriptorRanges;
+        table = &root_signature->parameters[i].descriptor_table;
+        range_count = p->DescriptorTable.NumDescriptorRanges;
         range_descriptor_offset = 0;
 
         root_signature->parameters[i].parameter_type = p->ParameterType;
@@ -623,7 +623,7 @@ static HRESULT d3d12_root_signature_init_root_descriptor_tables(struct d3d12_roo
 
         for (j = 0; j < range_count; ++j)
         {
-            const D3D12_DESCRIPTOR_RANGE *range = &p->u.DescriptorTable.pDescriptorRanges[j];
+            const D3D12_DESCRIPTOR_RANGE *range = &p->DescriptorTable.pDescriptorRanges[j];
 
             bool is_srv = range->RangeType == D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
             bool is_uav = range->RangeType == D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
@@ -795,8 +795,8 @@ static HRESULT d3d12_root_signature_init_root_descriptors(struct d3d12_root_sign
 
         binding = &root_signature->bindings[context->binding_index];
         binding->type = vkd3d_descriptor_type_from_d3d12_root_parameter_type(p->ParameterType);
-        binding->register_space = p->u.Descriptor.RegisterSpace;
-        binding->register_index = p->u.Descriptor.ShaderRegister;
+        binding->register_space = p->Descriptor.RegisterSpace;
+        binding->register_index = p->Descriptor.ShaderRegister;
         binding->register_count = 1;
         binding->descriptor_table = 0;  /* ignored */
         binding->descriptor_offset = 0; /* ignored */
@@ -807,8 +807,8 @@ static HRESULT d3d12_root_signature_init_root_descriptors(struct d3d12_root_sign
 
         param = &root_signature->parameters[i];
         param->parameter_type = p->ParameterType;
-        param->u.descriptor.binding = binding;
-        param->u.descriptor.packed_descriptor = context->packed_descriptor_index;
+        param->descriptor.binding = binding;
+        param->descriptor.packed_descriptor = context->packed_descriptor_index;
 
         context->packed_descriptor_index += 1;
         context->binding_index += 1;
@@ -1076,7 +1076,7 @@ HRESULT d3d12_root_signature_create(struct d3d12_device *device,
         return E_OUTOFMEMORY;
     }
 
-    hr = d3d12_root_signature_init(object, device, &root_signature_desc.d3d12.u.Desc_1_0);
+    hr = d3d12_root_signature_init(object, device, &root_signature_desc.d3d12.Desc_1_0);
     vkd3d_shader_free_root_signature(&root_signature_desc.vkd3d);
     if (FAILED(hr))
     {
@@ -1377,7 +1377,7 @@ static ULONG STDMETHODCALLTYPE d3d12_pipeline_state_AddRef(ID3D12PipelineState *
 static void d3d12_pipeline_state_destroy_graphics(struct d3d12_pipeline_state *state,
         struct d3d12_device *device)
 {
-    struct d3d12_graphics_pipeline_state *graphics = &state->u.graphics;
+    struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     struct vkd3d_compiled_pipeline *current, *e;
     unsigned int i;
@@ -1411,7 +1411,7 @@ static ULONG STDMETHODCALLTYPE d3d12_pipeline_state_Release(ID3D12PipelineState 
         if (d3d12_pipeline_state_is_graphics(state))
             d3d12_pipeline_state_destroy_graphics(state, device);
         else if (d3d12_pipeline_state_is_compute(state))
-            VK_CALL(vkDestroyPipeline(device->vk_device, state->u.compute.vk_pipeline, NULL));
+            VK_CALL(vkDestroyPipeline(device->vk_device, state->compute.vk_pipeline, NULL));
 
         vkd3d_free(state);
 
@@ -1459,7 +1459,7 @@ static HRESULT STDMETHODCALLTYPE d3d12_pipeline_state_SetName(ID3D12PipelineStat
 
     if (d3d12_pipeline_state_is_compute(state))
     {
-        return vkd3d_set_vk_object_name(state->device, (uint64_t)state->u.compute.vk_pipeline,
+        return vkd3d_set_vk_object_name(state->device, (uint64_t)state->compute.vk_pipeline,
                 VK_OBJECT_TYPE_PIPELINE, name);
     }
 
@@ -1621,7 +1621,7 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
     shader_interface.push_constant_ubo_binding = &root_signature->push_constant_ubo_binding;
 
     if (FAILED(hr = vkd3d_create_compute_pipeline(device, &desc->cs, &shader_interface,
-            root_signature->vk_pipeline_layout, &state->u.compute.vk_pipeline)))
+            root_signature->vk_pipeline_layout, &state->compute.vk_pipeline)))
     {
         WARN("Failed to create Vulkan compute pipeline, hr %#x.\n", hr);
         return hr;
@@ -1629,7 +1629,7 @@ static HRESULT d3d12_pipeline_state_init_compute(struct d3d12_pipeline_state *st
 
     if (FAILED(hr = vkd3d_private_store_init(&state->private_store)))
     {
-        VK_CALL(vkDestroyPipeline(device->vk_device, state->u.compute.vk_pipeline, NULL));
+        VK_CALL(vkDestroyPipeline(device->vk_device, state->compute.vk_pipeline, NULL));
         return hr;
     }
 
@@ -2161,7 +2161,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
 {
     const VkPhysicalDeviceFeatures *features = &device->device_info.features2.features;
     unsigned int ps_output_swizzle[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
-    struct d3d12_graphics_pipeline_state *graphics = &state->u.graphics;
+    struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     const D3D12_STREAM_OUTPUT_DESC *so_desc = &desc->stream_output;
     VkVertexInputBindingDivisorDescriptionEXT *binding_divisor;
@@ -2332,7 +2332,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
     ps_shader_parameters[0].name = VKD3D_SHADER_PARAMETER_NAME_RASTERIZER_SAMPLE_COUNT;
     ps_shader_parameters[0].type = VKD3D_SHADER_PARAMETER_TYPE_IMMEDIATE_CONSTANT;
     ps_shader_parameters[0].data_type = VKD3D_SHADER_PARAMETER_DATA_TYPE_UINT32;
-    ps_shader_parameters[0].u.immediate_constant.u.u32 = sample_count;
+    ps_shader_parameters[0].immediate_constant.u32 = sample_count;
 
     ps_compile_args.type = VKD3D_SHADER_STRUCTURE_TYPE_COMPILE_ARGUMENTS;
     ps_compile_args.next = NULL;
@@ -2638,7 +2638,7 @@ static HRESULT d3d12_pipeline_state_init_graphics(struct d3d12_pipeline_state *s
 fail:
     for (i = 0; i < graphics->stage_count; ++i)
     {
-        VK_CALL(vkDestroyShaderModule(device->vk_device, state->u.graphics.stages[i].module, NULL));
+        VK_CALL(vkDestroyShaderModule(device->vk_device, state->graphics.stages[i].module, NULL));
     }
     vkd3d_shader_free_shader_signature(&input_signature);
 
@@ -2754,7 +2754,7 @@ static enum VkPrimitiveTopology vk_topology_from_d3d12_topology(D3D12_PRIMITIVE_
 static VkPipeline d3d12_pipeline_state_find_compiled_pipeline(const struct d3d12_pipeline_state *state,
         const struct vkd3d_pipeline_key *key, VkRenderPass *vk_render_pass)
 {
-    const struct d3d12_graphics_pipeline_state *graphics = &state->u.graphics;
+    const struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
     struct d3d12_device *device = state->device;
     VkPipeline vk_pipeline = VK_NULL_HANDLE;
     struct vkd3d_compiled_pipeline *current;
@@ -2786,7 +2786,7 @@ static VkPipeline d3d12_pipeline_state_find_compiled_pipeline(const struct d3d12
 static bool d3d12_pipeline_state_put_pipeline_to_cache(struct d3d12_pipeline_state *state,
         const struct vkd3d_pipeline_key *key, VkPipeline vk_pipeline, VkRenderPass vk_render_pass)
 {
-    struct d3d12_graphics_pipeline_state *graphics = &state->u.graphics;
+    struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
     struct vkd3d_compiled_pipeline *compiled_pipeline, *current;
     struct d3d12_device *device = state->device;
     int rc;
@@ -2827,7 +2827,7 @@ VkPipeline d3d12_pipeline_state_get_or_create_pipeline(struct d3d12_pipeline_sta
 {
     VkVertexInputBindingDescription bindings[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
     const struct vkd3d_vk_device_procs *vk_procs = &state->device->vk_procs;
-    struct d3d12_graphics_pipeline_state *graphics = &state->u.graphics;
+    struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
     VkPipelineVertexInputDivisorStateCreateInfoEXT input_divisor_info;
     VkPipelineTessellationStateCreateInfo tessellation_info;
     VkPipelineVertexInputStateCreateInfo input_desc;

--- a/libs/vkd3d/utils.c
+++ b/libs/vkd3d/utils.c
@@ -950,15 +950,15 @@ static HRESULT vkd3d_private_store_set_private_data(struct vkd3d_private_store *
         ptr = &data;
     }
 
-    if (!(d = vkd3d_malloc(offsetof(struct vkd3d_private_data, u.data[data_size]))))
+    if (!(d = vkd3d_malloc(offsetof(struct vkd3d_private_data, data[data_size]))))
         return E_OUTOFMEMORY;
 
     d->tag = *tag;
     d->size = data_size;
     d->is_object = is_object;
-    memcpy(d->u.data, ptr, data_size);
+    memcpy(d->data, ptr, data_size);
     if (is_object)
-        IUnknown_AddRef(d->u.object);
+        IUnknown_AddRef(d->object);
 
     if ((old_data = vkd3d_private_store_get_private_data(store, tag)))
         vkd3d_private_data_destroy(old_data);
@@ -1003,8 +1003,8 @@ HRESULT vkd3d_get_private_data(struct vkd3d_private_store *store,
     }
 
     if (data->is_object)
-        IUnknown_AddRef(data->u.object);
-    memcpy(out, data->u.data, data->size);
+        IUnknown_AddRef(data->object);
+    memcpy(out, data->data, data->size);
 
 done:
     pthread_mutex_unlock(&store->mutex);

--- a/libs/vkd3d/vkd3d_main.c
+++ b/libs/vkd3d/vkd3d_main.c
@@ -155,7 +155,7 @@ static const D3D12_ROOT_SIGNATURE_DESC * STDMETHODCALLTYPE d3d12_root_signature_
     TRACE("iface %p.\n", iface);
 
     assert(deserializer->desc.d3d12.Version == D3D_ROOT_SIGNATURE_VERSION_1_0);
-    return &deserializer->desc.d3d12.u.Desc_1_0;
+    return &deserializer->desc.d3d12.Desc_1_0;
 }
 
 static const struct ID3D12RootSignatureDeserializerVtbl d3d12_root_signature_deserializer_vtbl =
@@ -449,7 +449,7 @@ HRESULT vkd3d_serialize_root_signature(const D3D12_ROOT_SIGNATURE_DESC *desc,
         *error_blob = NULL;
 
     vkd3d_desc.version = VKD3D_ROOT_SIGNATURE_VERSION_1_0;
-    vkd3d_desc.u.v_1_0 = *(const struct vkd3d_root_signature_desc *)desc;
+    vkd3d_desc.v_1_0 = *(const struct vkd3d_root_signature_desc *)desc;
     if ((ret = vkd3d_shader_serialize_root_signature(&vkd3d_desc, &dxbc)) < 0)
     {
         WARN("Failed to serialize root signature, vkd3d result %d.\n", ret);

--- a/libs/vkd3d/vkd3d_private.h
+++ b/libs/vkd3d/vkd3d_private.h
@@ -20,7 +20,6 @@
 #define __VKD3D_PRIVATE_H
 
 #define COBJMACROS
-#define NONAMELESSUNION
 #define VK_NO_PROTOTYPES
 
 #include "vkd3d_common.h"
@@ -309,13 +308,13 @@ struct vkd3d_private_data
     {
         BYTE data[1];
         IUnknown *object;
-    } u;
+    };
 };
 
 static inline void vkd3d_private_data_destroy(struct vkd3d_private_data *data)
 {
     if (data->is_object)
-        IUnknown_Release(data->u.object);
+        IUnknown_Release(data->object);
     list_remove(&data->entry);
     vkd3d_free(data);
 }
@@ -438,7 +437,7 @@ struct d3d12_sparse_tile
     {
         struct d3d12_sparse_image_region image;
         struct d3d12_sparse_buffer_region buffer;
-    } u;
+    };
     VkDeviceMemory vk_memory;
     VkDeviceSize vk_offset;
 };
@@ -470,7 +469,7 @@ struct d3d12_resource
     {
         VkBuffer vk_buffer;
         VkImage vk_image;
-    } u;
+    };
     unsigned int flags;
 
     struct d3d12_heap *heap;
@@ -542,7 +541,7 @@ struct vkd3d_view
         VkBufferView vk_buffer_view;
         VkImageView vk_image_view;
         VkSampler vk_sampler;
-    } u;
+    };
     VkBufferView vk_counter_view;
     VkDeviceAddress vk_counter_address;
     const struct vkd3d_format *format;
@@ -596,7 +595,7 @@ struct d3d12_desc
     {
         VkDescriptorBufferInfo vk_cbv_info;
         struct vkd3d_view *view;
-    } u;
+    } info;
 };
 
 static inline struct d3d12_desc *d3d12_desc_from_cpu_handle(D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle)
@@ -807,7 +806,7 @@ struct d3d12_root_parameter
         struct d3d12_root_constant constant;
         struct d3d12_root_descriptor descriptor;
         struct d3d12_root_descriptor_table descriptor_table;
-    } u;
+    };
 };
 
 /* ID3D12RootSignature */
@@ -938,7 +937,7 @@ struct d3d12_pipeline_state
     {
         struct d3d12_graphics_pipeline_state graphics;
         struct d3d12_compute_pipeline_state compute;
-    } u;
+    };
     VkPipelineBindPoint vk_bind_point;
 
     struct d3d12_device *device;
@@ -960,7 +959,7 @@ static inline bool d3d12_pipeline_state_has_unknown_dsv_format(struct d3d12_pipe
 {
     if (d3d12_pipeline_state_is_graphics(state))
     {
-        struct d3d12_graphics_pipeline_state *graphics = &state->u.graphics;
+        struct d3d12_graphics_pipeline_state *graphics = &state->graphics;
 
         return graphics->null_attachment_mask & dsv_attachment_mask(graphics);
     }
@@ -1311,7 +1310,7 @@ struct d3d12_command_queue_submission
         struct d3d12_command_queue_submission_signal signal;
         struct d3d12_command_queue_submission_execute execute;
         struct d3d12_command_queue_submission_bind_sparse bind_sparse;
-    } u;
+    };
 };
 
 struct vkd3d_timeline_semaphore

--- a/tests/d3d12.c
+++ b/tests/d3d12.c
@@ -9974,7 +9974,7 @@ static void test_shader_instructions(void)
                 struct uvec4 src0;
                 struct uvec4 src1;
                 struct uvec4 src2;
-            } u;
+            };
             struct
             {
                 struct ivec4 src0;


### PR DESCRIPTION
This makes it consistent across tests and vkd3d.