### PR TITLE
vkd3d-shader: Don't use return value semantics in void functions

### DIFF
--- a/libs/vkd3d-shader/spirv.c
+++ b/libs/vkd3d-shader/spirv.c
@@ -649,13 +649,13 @@ static void vkd3d_spirv_build_op3v(struct vkd3d_spirv_stream *stream,
 static void vkd3d_spirv_build_op2(struct vkd3d_spirv_stream *stream,
         SpvOp op, uint32_t operand0, uint32_t operand1)
 {
-    return vkd3d_spirv_build_op2v(stream, op, operand0, operand1, NULL, 0);
+    vkd3d_spirv_build_op2v(stream, op, operand0, operand1, NULL, 0);
 }
 
 static void vkd3d_spirv_build_op3(struct vkd3d_spirv_stream *stream,
         SpvOp op, uint32_t operand0, uint32_t operand1, uint32_t operand2)
 {
-    return vkd3d_spirv_build_op2v(stream, op, operand0, operand1, &operand2, 1);
+    vkd3d_spirv_build_op2v(stream, op, operand0, operand1, &operand2, 1);
 }
 
 static uint32_t vkd3d_spirv_build_op_rv(struct vkd3d_spirv_builder *builder,
@@ -909,7 +909,7 @@ static void vkd3d_spirv_build_op_decorate(struct vkd3d_spirv_builder *builder,
 static void vkd3d_spirv_build_op_decorate1(struct vkd3d_spirv_builder *builder,
         uint32_t target_id, SpvDecoration decoration, uint32_t operand0)
 {
-    return vkd3d_spirv_build_op_decorate(builder, target_id, decoration, &operand0, 1);
+    vkd3d_spirv_build_op_decorate(builder, target_id, decoration, &operand0, 1);
 }
 
 static void vkd3d_spirv_build_op_member_decorate(struct vkd3d_spirv_builder *builder,
@@ -1257,22 +1257,22 @@ static void vkd3d_spirv_build_op_store(struct vkd3d_spirv_builder *builder,
         uint32_t pointer_id, uint32_t object_id, uint32_t memory_access)
 {
     if (!memory_access)
-        return vkd3d_spirv_build_op2(&builder->function_stream, SpvOpStore,
-                pointer_id, object_id);
+        vkd3d_spirv_build_op2(&builder->function_stream, SpvOpStore,
+            pointer_id, object_id);
     else
-        return vkd3d_spirv_build_op3(&builder->function_stream, SpvOpStore,
-                pointer_id, object_id, memory_access);
+        vkd3d_spirv_build_op3(&builder->function_stream, SpvOpStore,
+            pointer_id, object_id, memory_access);
 }
 
 static void vkd3d_spirv_build_op_copy_memory(struct vkd3d_spirv_builder *builder,
         uint32_t target_id, uint32_t source_id, uint32_t memory_access)
 {
     if (!memory_access)
-        return vkd3d_spirv_build_op2(&builder->function_stream, SpvOpCopyMemory,
-                target_id, source_id);
+        vkd3d_spirv_build_op2(&builder->function_stream, SpvOpCopyMemory,
+            target_id, source_id);
     else
-        return vkd3d_spirv_build_op3(&builder->function_stream, SpvOpCopyMemory,
-                target_id, source_id, memory_access);
+        vkd3d_spirv_build_op3(&builder->function_stream, SpvOpCopyMemory,
+            target_id, source_id, memory_access);
 }
 
 static uint32_t vkd3d_spirv_build_op_select(struct vkd3d_spirv_builder *builder,
@@ -1602,12 +1602,12 @@ static uint32_t vkd3d_spirv_build_op_image_query_lod(struct vkd3d_spirv_builder 
 
 static void vkd3d_spirv_build_op_emit_vertex(struct vkd3d_spirv_builder *builder)
 {
-    return vkd3d_spirv_build_op(&builder->function_stream, SpvOpEmitVertex);
+    vkd3d_spirv_build_op(&builder->function_stream, SpvOpEmitVertex);
 }
 
 static void vkd3d_spirv_build_op_end_primitive(struct vkd3d_spirv_builder *builder)
 {
-    return vkd3d_spirv_build_op(&builder->function_stream, SpvOpEndPrimitive);
+    vkd3d_spirv_build_op(&builder->function_stream, SpvOpEndPrimitive);
 }
 
 static void vkd3d_spirv_build_op_control_barrier(struct vkd3d_spirv_builder *builder,
@@ -3507,8 +3507,9 @@ static void vkd3d_dxbc_compiler_emit_store(struct vkd3d_dxbc_compiler *compiler,
 
     if (component_count == 1)
     {
-        return vkd3d_dxbc_compiler_emit_store_scalar(compiler,
-                dst_id, dst_write_mask, component_type, storage_class, write_mask, val_id);
+        vkd3d_dxbc_compiler_emit_store_scalar(compiler,
+            dst_id, dst_write_mask, component_type, storage_class, write_mask, val_id);
+        return;
     }
 
     dst_component_count = vkd3d_write_mask_component_count(dst_write_mask);


### PR DESCRIPTION
Fixes warnings in MSVC.