### PR TITLE
build: Fix MinGW build.

### DIFF
--- a/demos/demo.h
+++ b/demos/demo.h
@@ -25,6 +25,14 @@
  * which leads to the "multiple storage classes in declaration
  * specifiers" compiler error.
  */
+#ifdef __MINGW32__
+#include <_mingw.h>
+# ifdef __MINGW64_VERSION_MAJOR
+#  undef __forceinline
+#  define __forceinline __inline__ __attribute__((__always_inline__,__gnu_inline__))
+# endif
+#endif
+
 #include <vkd3d_windows.h>
 #define WIDL_C_INLINE_WRAPPERS
 #define COBJMACROS

--- a/tests/d3d12_crosstest.h
+++ b/tests/d3d12_crosstest.h
@@ -19,6 +19,21 @@
 #ifndef __VKD3D_D3D12_CROSSTEST_H
 #define __VKD3D_D3D12_CROSSTEST_H
 
+/* Hack for MinGW-w64 headers.
+ *
+ * We want to use WIDL C inline wrappers because some methods
+ * in D3D12 interfaces return aggregate objects. Unfortunately,
+ * WIDL C inline wrappers are broken when used with MinGW-w64
+ * headers because FORCEINLINE expands to extern inline
+ * which leads to the "multiple storage classes in declaration
+ * specifiers" compiler error.
+ */
+#ifdef __MINGW32__
+#include <_mingw.h>
+# ifdef __MINGW64_VERSION_MAJOR
+#  undef __forceinline
+#  define __forceinline __inline__ __attribute__((__always_inline__,__gnu_inline__))
+# endif
 # define _HRESULT_DEFINED
 typedef int HRESULT;
 #endif


### PR DESCRIPTION
Revert removal of MinGW forceinline hacks.
They are necessary or MinGW fails to build.

Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>