### PR TITLE
vkd3d-shader: Build statically

### DIFF
--- a/include/private/vkd3d_debug.h
+++ b/include/private/vkd3d_debug.h
@@ -90,8 +90,6 @@ const char *debugstr_w(const WCHAR *wstr, size_t wchar_size) DECLSPEC_HIDDEN;
 
 #define FIXME_ONCE VKD3D_DBG_LOG_ONCE(FIXME, WARN)
 
-#define VKD3D_DEBUG_ENV_NAME(name) const char *vkd3d_dbg_env_name = name
-
 static inline const char *debugstr_guid(const GUID *guid)
 {
     if (!guid)

--- a/libs/vkd3d-common/debug.c
+++ b/libs/vkd3d-common/debug.c
@@ -31,8 +31,6 @@
 #define VKD3D_DEBUG_BUFFER_COUNT 64
 #define VKD3D_DEBUG_BUFFER_SIZE 512
 
-extern const char *vkd3d_dbg_env_name DECLSPEC_HIDDEN;
-
 static const char *debug_level_names[] =
 {
     /* VKD3D_DBG_LEVEL_NONE  */ "none",
@@ -51,7 +49,7 @@ enum vkd3d_dbg_level vkd3d_dbg_get_level(void)
     if (level != ~0u)
         return level;
 
-    if (!(vkd3d_debug = getenv(vkd3d_dbg_env_name)))
+    if (!(vkd3d_debug = getenv("VKD3D_DEBUG")))
         vkd3d_debug = "";
 
     for (i = 0; i < ARRAY_SIZE(debug_level_names); ++i)

--- a/libs/vkd3d-shader/meson.build
+++ b/libs/vkd3d-shader/meson.build
@@ -7,11 +7,9 @@ vkd3d_shader_src = [
   'vkd3d_shader_main.c',
 ]
 
-vkd3d_shader_lib = shared_library('vkd3d-shader', vkd3d_shader_src, vkd3d_headers,
+vkd3d_shader_lib = static_library('vkd3d-shader', vkd3d_shader_src, vkd3d_headers,
   dependencies        : [ vkd3d_common_dep, dxil_spirv_lib ],
   include_directories : vkd3d_private_includes,
-  install             : true,
-  vs_module_defs      : 'vkd3d_shader.def',
   override_options    : [ 'c_std='+vkd3d_c_std ])
 
 vkd3d_shader_dep = declare_dependency(

--- a/libs/vkd3d-shader/meson.build
+++ b/libs/vkd3d-shader/meson.build
@@ -8,7 +8,7 @@ vkd3d_shader_src = [
 ]
 
 vkd3d_shader_lib = static_library('vkd3d-shader', vkd3d_shader_src, vkd3d_headers,
-  dependencies        : [ vkd3d_common_dep, dxil_spirv_lib ],
+  dependencies        : [ vkd3d_common_dep ] + dxil_spirv_deps,
   include_directories : vkd3d_private_includes,
   override_options    : [ 'c_std='+vkd3d_c_std ])
 

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -20,8 +20,6 @@
 
 #include <stdio.h>
 
-VKD3D_DEBUG_ENV_NAME("VKD3D_SHADER_DEBUG");
-
 static void vkd3d_shader_dump_blob(const char *path, const char *prefix, const void *data, size_t size,
         unsigned int id, const char *ext)
 {

--- a/libs/vkd3d-utils/vkd3d_utils_main.c
+++ b/libs/vkd3d-utils/vkd3d_utils_main.c
@@ -19,8 +19,6 @@
 #include "vkd3d_common.h"
 #include "vkd3d_utils_private.h"
 
-VKD3D_DEBUG_ENV_NAME("VKD3D_DEBUG");
-
 HRESULT WINAPI D3D12GetDebugInterface(REFIID iid, void **debug)
 {
     FIXME("iid %s, debug %p stub!\n", debugstr_guid(iid), debug);

--- a/libs/vkd3d/vkd3d_main.c
+++ b/libs/vkd3d/vkd3d_main.c
@@ -19,8 +19,6 @@
 #define INITGUID
 #include "vkd3d_private.h"
 
-VKD3D_DEBUG_ENV_NAME("VKD3D_DEBUG");
-
 HRESULT vkd3d_create_device(const struct vkd3d_device_create_info *create_info,
         REFIID iid, void **device)
 {

--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,15 @@ vkd3d_version = vcs_tag(
 
 cmake = import('cmake')
 dxil_spirv = cmake.subproject('dxil-spirv', cmake_options: ['-DDXIL_SPIRV_CLI=OFF'] )
-dxil_spirv_lib = dxil_spirv.dependency('dxil-spirv-c-shared')
+dxil_spirv_deps = [
+  dxil_spirv.dependency('dxil-spirv-c-static'),
+  dxil_spirv.dependency('dxil-converter'),
+  dxil_spirv.dependency('dxil-debug'),
+  dxil_spirv.dependency('spirv-module'),
+  dxil_spirv.dependency('glslang-spirv-builder'),
+  dxil_spirv.dependency('llvm-bc'),
+  dxil_spirv.dependency('bc-decoder'),
+]
 
 subdir('include')
 subdir('libs')


### PR DESCRIPTION
I had to manually pull in the dependencies of `dxil-spirv` in Meson to link against; initially I thought that was because they weren't declared `PUBLIC` in CMake, but that didn't work either -- seems to be a bug with the Meson CMake integration.

This also tosses the `VKD3D_DEBUG_ENV_NAME` stuff that's really janky, it links back into vkd3d-common from the modules so you can set the env var to enable debugging per-module. Given this is static now we'd have two so that doesn't work anymore, so I just made it use `VKD3D_DEBUG` always which imo is much more sensible.