### PR TITLE
Remove SPIRV-Tools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,9 +85,9 @@ libvkd3d_shader_la_SOURCES = \
 	libs/vkd3d-shader/vkd3d_shader.map \
 	libs/vkd3d-shader/vkd3d_shader_main.c \
 	libs/vkd3d-shader/vkd3d_shader_private.h
-libvkd3d_shader_la_CFLAGS = $(AM_CFLAGS) @SPIRV_TOOLS_CFLAGS@ @dxil_spirv_c_shared_CFLAGS@
+libvkd3d_shader_la_CFLAGS = $(AM_CFLAGS) @dxil_spirv_c_shared_CFLAGS@
 libvkd3d_shader_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0
-libvkd3d_shader_la_LIBADD = libvkd3d-common.la @SPIRV_TOOLS_LIBS@ @dxil_spirv_c_shared_LIBS@
+libvkd3d_shader_la_LIBADD = libvkd3d-common.la @dxil_spirv_c_shared_LIBS@
 if HAVE_LD_VERSION_SCRIPT
 libvkd3d_shader_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libs/vkd3d-shader/vkd3d_shader.map
 EXTRA_libvkd3d_shader_la_DEPENDENCIES = $(srcdir)/libs/vkd3d-shader/vkd3d_shader.map

--- a/configure.ac
+++ b/configure.ac
@@ -9,8 +9,6 @@ AC_ARG_VAR([WIDL], [widl IDL compiler])
 AC_ARG_VAR([CROSSCC32], [32-bit Windows cross compiler])
 AC_ARG_VAR([CROSSCC64], [64-bit Windows cross compiler])
 AC_ARG_WITH([xcb], AS_HELP_STRING([--with-xcb], [Build with XCB library (default: test)]))
-AC_ARG_WITH([spirv-tools], AS_HELP_STRING([--with-spirv-tools],
-                                          [Build with SPIRV-Tools library (default: disabled)]))
 AC_ARG_WITH([dxil-spirv], AS_HELP_STRING([--with-dxil-spirv],
                                          [Build with dxil-spirv library for DXIL support (default: enabled)]))
 AC_ARG_ENABLE([demos],
@@ -78,11 +76,6 @@ AC_CHECK_LIB([dl], [dlopen],
 AC_ARG_VAR([PTHREAD_LIBS], [linker flags for pthreads])
 VKD3D_CHECK_PTHREAD
 
-AS_IF([test "x$with_spirv_tools" = "xyes"],
-      [PKG_CHECK_MODULES([SPIRV_TOOLS], [SPIRV-Tools-shared],
-      [AC_DEFINE([HAVE_SPIRV_TOOLS], [1], [Define to 1 if you have SPIRV-Tools.])])],
-      [with_spirv_tools=no])
-
 HAVE_XCB=no
 AS_IF([test "x$with_xcb" != "xno"],
       [PKG_CHECK_MODULES([XCB], [xcb xcb-keysyms],
@@ -129,7 +122,6 @@ AS_ECHO(["
   widl: ${WIDL}
 
   Have XCB: ${HAVE_XCB}
-  Have SPIRV-Tools: ${with_spirv_tools}
   Have dxil-spirv: ${HAVE_DXIL_SPV}
 
   Building demos: ${enable_demos}


### PR DESCRIPTION
Removes quite obsolete dependency on SPIRV-Tools, which, from what I was told, is unused anyway.

Affects only autotools–based builds, Meson never used it in the first place.