### PR TITLE
build: Enable warning level 2

### DIFF
--- a/libs/vkd3d-common/utf8.c
+++ b/libs/vkd3d-common/utf8.c
@@ -103,6 +103,12 @@ static uint32_t vkd3d_utf16_read(const uint16_t **src)
     return 0x10000 + ((s[0] & 0x3ff) << 10) + (s[1] & 0x3ff);
 }
 
+static inline bool vkd3d_string_should_loop(size_t max_elements, const uint16_t* src, const uint16_t* wstr)
+{
+    uintptr_t cursor_pos = ((uintptr_t)src) - (uintptr_t)wstr;
+    return (!max_elements || cursor_pos < max_elements) && *src;
+}
+
 static char *vkd3d_strdup_w16_utf8(const uint16_t *wstr, size_t max_elements)
 {
     const uint16_t *src = wstr;
@@ -110,7 +116,7 @@ static char *vkd3d_strdup_w16_utf8(const uint16_t *wstr, size_t max_elements)
     char *dst, *utf8;
     uint32_t c;
 
-    while ((!max_elements || ((src - wstr) < max_elements)) && *src)
+    while (vkd3d_string_should_loop(max_elements, src, wstr))
     {
         if (!(c = vkd3d_utf16_read(&src)))
             continue;
@@ -123,7 +129,7 @@ static char *vkd3d_strdup_w16_utf8(const uint16_t *wstr, size_t max_elements)
 
     utf8 = dst;
     src = wstr;
-    while ((!max_elements || ((src - wstr) < max_elements)) && *src)
+    while (vkd3d_string_should_loop(max_elements, src, wstr))
     {
         if (!(c = vkd3d_utf16_read(&src)))
             continue;
@@ -140,7 +146,7 @@ static char *vkd3d_strdup_w32_utf8(const uint32_t *wstr, size_t max_elements)
     size_t dst_size = 0;
     char *dst, *utf8;
 
-    while ((!max_elements || ((src - wstr) < max_elements)) && *src)
+    while (vkd3d_string_should_loop(max_elements, src, wstr))
         dst_size += vkd3d_utf8_len(*src++);
     ++dst_size;
 
@@ -149,7 +155,7 @@ static char *vkd3d_strdup_w32_utf8(const uint32_t *wstr, size_t max_elements)
 
     utf8 = dst;
     src = wstr;
-    while ((!max_elements || ((src - wstr) < max_elements)) && *src)
+    while (vkd3d_string_should_loop(max_elements, src, wstr))
         vkd3d_utf8_append(&utf8, *src++);
     *utf8 = 0;
 

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -2352,13 +2352,13 @@ static HRESULT d3d12_resource_init_sparse_info(struct d3d12_resource *resource,
             region->extent.height = min(block_extent.height, mip_extent.height - region->offset.y);
             region->extent.depth = min(block_extent.depth, mip_extent.depth - region->offset.z);
 
-            if (++tile_offset.x == sparse->tilings[subresource].WidthInTiles)
+            if (++tile_offset.x == (int32_t)sparse->tilings[subresource].WidthInTiles)
             {
                 tile_offset.x = 0;
-                if (++tile_offset.y == sparse->tilings[subresource].HeightInTiles)
+                if (++tile_offset.y == (int32_t)sparse->tilings[subresource].HeightInTiles)
                 {
                     tile_offset.y = 0;
-                    if (++tile_offset.z == sparse->tilings[subresource].DepthInTiles)
+                    if (++tile_offset.z == (int32_t)sparse->tilings[subresource].DepthInTiles)
                     {
                         tile_offset.z = 0;
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,6 @@
-project('vkd3d', ['c'], version : '1.1', meson_version : '>= 0.51')
+project('vkd3d', ['c'], version : '1.1', meson_version : '>= 0.51', default_options : [
+  'warning_level=2',
+])
 
 cpu_family = target_machine.cpu_family()
 


### PR DESCRIPTION
Fix some signed comparison warnings and enable warning level 2 in Meson
(Equivalent to -Wall -Wextra)

Should help spot some of the enum issues we've had in the past...