### PR TITLE
build: Use Meson subproject for dxil-spirv

### DIFF
--- a/build-win32.txt
+++ b/build-win32.txt
@@ -3,7 +3,6 @@ c = 'i686-w64-mingw32-gcc'
 cpp = 'i686-w64-mingw32-g++'
 ar = 'i686-w64-mingw32-ar'
 strip = 'i686-w64-mingw32-strip'
-cmake = 'i686-w64-mingw32-cmake'
 
 [properties]
 c_args=['-msse', '-msse2']

--- a/build-win64.txt
+++ b/build-win64.txt
@@ -3,7 +3,6 @@ c = 'x86_64-w64-mingw32-gcc'
 cpp = 'x86_64-w64-mingw32-g++'
 ar = 'x86_64-w64-mingw32-ar'
 strip = 'x86_64-w64-mingw32-strip'
-cmake = 'x86_64-w64-mingw32-cmake'
 
 [properties]
 c_link_args = ['-static', '-static-libgcc']

--- a/libs/vkd3d-shader/meson.build
+++ b/libs/vkd3d-shader/meson.build
@@ -8,7 +8,7 @@ vkd3d_shader_src = [
 ]
 
 vkd3d_shader_lib = static_library('vkd3d-shader', vkd3d_shader_src, vkd3d_headers,
-  dependencies        : [ vkd3d_common_dep ] + dxil_spirv_deps,
+  dependencies        : [ vkd3d_common_dep, dxil_spirv_dep ],
   include_directories : vkd3d_private_includes,
   override_options    : [ 'c_std='+vkd3d_c_std ])
 

--- a/meson.build
+++ b/meson.build
@@ -57,17 +57,8 @@ vkd3d_version = vcs_tag(
   input   : 'vkd3d_version.c.in',
   output  : 'vkd3d_version.c')
 
-cmake = import('cmake')
-dxil_spirv = cmake.subproject('dxil-spirv', cmake_options: ['-DDXIL_SPIRV_CLI=OFF'] )
-dxil_spirv_deps = [
-  dxil_spirv.dependency('dxil-spirv-c-static'),
-  dxil_spirv.dependency('dxil-converter'),
-  dxil_spirv.dependency('dxil-debug'),
-  dxil_spirv.dependency('spirv-module'),
-  dxil_spirv.dependency('glslang-spirv-builder'),
-  dxil_spirv.dependency('llvm-bc'),
-  dxil_spirv.dependency('bc-decoder'),
-]
+dxil_spirv = subproject('dxil-spirv')
+dxil_spirv_dep = dxil_spirv.get_variable('dxil_spirv_dep')
 
 subdir('include')
 subdir('libs')


### PR DESCRIPTION
Removes the CMake dependency and solves some trouble building.

Signed-off-by: Joshua Ashton <joshua@froggi.es>